### PR TITLE
Fix link on homepage to last years talks

### DIFF
--- a/_pages/homepage-coming-soon.html
+++ b/_pages/homepage-coming-soon.html
@@ -310,7 +310,7 @@ title: DjangoCon US 2022 conference will take place in San Diego, California fro
             class="feature-icon">
           <h3>Learn from Django's Brightest</h3>
           <p>Every conference is packed with talks and workshops by Django veterans and enthusiastic first-time presenters.</p>
-          <a href="https://2022.djangocon.us/talks/" class="cta">See last year's schedule</a>
+          <a href="https://2021.djangocon.us/talks/" class="cta">See last year's schedule</a>
         </section>
         <section class="feature">
           <img


### PR DESCRIPTION
Earlier commit (9b75bcf) changed the link for last year's talks to this year during a bulk change from 2021->2022. This one instance of 2021 should have stayed the same

Changes proposed in this PR:

- Changes 2022 to 2021 in link for "See last year's schedule" in homepage-coming-soon.html
