### PR TITLE
Enable more ticket buttons and update pricing

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,8 +2,8 @@
   <a href="/about/">About</a>
   <ul class="menu vertical nested">
     <li><a href="/about/">About DjangoCon US</a></li>
-    {% comment %}
     <li><a href="/tickets/">Tickets</a></li>
+    {% comment %}
     <li><a href="/job-board/">Jobs Board</a></li>
     {% endcomment %}
     <li><a href="/faq/">FAQ</a></li>
@@ -52,10 +52,8 @@
   </ul>
 </li>
 <li><a href="/news/">News</a></li>
-{% comment %}
 <li>
   <a href="{{ site.ticket_link }}" class="button hollow">
     Buy Tickets
   </a>
 </li>
-{% endcomment %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -18,9 +18,7 @@ layout: base
         </span>
       </div>
 
-      {% comment %}
       <a class="button" href="{{ site.ticket_link }}">Buy Tickets</a>
-      {% endcomment %}
 
       <a class="button" href="http://eepurl.com/bpvu2f">Join Mailing List</a>
 
@@ -28,7 +26,7 @@ layout: base
         <a class="button" href="/schedule/">Conference Schedule</a>
       {% endcomment %}
         <a class="button" href="{{ site.cfp_application }}">Submit Talk</a>
-      
+
     </div>
   </div>
 </header>

--- a/_layouts/session-details.html
+++ b/_layouts/session-details.html
@@ -58,11 +58,9 @@ layout: base
       </h2>
       {{ content }}
 
-      {% comment %}
       <a href="{{ site.ticket_link }}" class="button">
         Buy Tickets Now
       </a>
-      {% endcomment %}
 
     </div>
   </div><!-- end .row -->

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -29,7 +29,7 @@ title: Full Conference Schedule
   <div class="row column">
     <h2 class="day">Tutorials: Sunday, October 16</h2>
     <p class="lead">
-      Tutorials are a separate registration and are $195 per session. {% comment %}Buy <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell out!{% endcomment %}
+      Tutorials are a separate registration and are $199 per session. Buy <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell out!
     </p>
     <ul class="schedule">
       {% for post in site.schedule %}

--- a/_pages/tickets.html
+++ b/_pages/tickets.html
@@ -15,13 +15,10 @@ description: Information about buying tickets to DjangoCon US
     <div class="column small-12 medium-6">
       <h2>What ticket should I buy?</h2>
       <p>Most people should buy an <strong>Individual</strong> ticket. If your company is paying, they should use the <strong>Corporate</strong> rate (or the <strong>Concierge</strong> rate for more flexibility; see below). For those who can't afford the Individual ticket, a <strong>discounted</strong> ticket is available; see below. And for those who want to go above and beyond and support our mission, check out the <strong>Patron</strong> ticket.</p>
-
-      {% comment %}
       <a
         class="button"
         href="{{ site.ticket_link }}"
         target="_blank">Buy Tickets Now</a>
-        {% endcomment %}
     </div>
     <div class="show-for-medium column medium-5" aria-hidden="true">
       <div class="callout">
@@ -51,7 +48,7 @@ description: Information about buying tickets to DjangoCon US
      <thead>
       <tr>
        <th>Type</th>
-       <th>Early Bird</th>
+       {% comment %}<th>Early Bird</th>{% endcommment %}
        <th>Full Price</th>
        <th>Who?</th>
       </tr>
@@ -59,43 +56,43 @@ description: Information about buying tickets to DjangoCon US
      <tbody>
       <tr>
        <td>Individual</td>
-       <td>$495</td>
-       <td>$595</td>
+       {% comment %}<td>$499</td>{% endcomment %}
+       <td>$599</td>
        <td><div>People paying their own way</div><div>Companies with 5 or fewer employees</div></td>
       </tr>
       <tr>
        <td>Corporate</td>
-       <td>$695</td>
-       <td>$795</td>
+       {% comment %}<td>$699</td>{% endcomment %}
+       <td>$799</td>
        <td><div>Companies with more than 5 employees</div><div>(including state agencies and nonprofits, if able)</div></td>
       </tr>
       <tr>
        <td>Patron</td>
-       <td>&mdash;</td>
-       <td>$995</td>
+       {% comment %}<td>&mdash;</td>{% endcomment %}
+       <td>$999</td>
        <td><div>Attendees who wish to support our mission a little extra</div><div>Will be invited to a thank-you event</div></td>
       </tr>
       <tr>
        <td>Corporate Concierge Service</td>
-       <td>&mdash;</td>
-       <td>$995</td>
+       {% comment %}<td>&mdash;</td>{% endcomment %}
+       <td>$999</td>
        <td><div>Companies who need to buy several tickets now, and register specific people later</div><div>Companies who cannot pay with credit card</div><div>Price is per ticket</div></td>
       </tr>
       <tr>
        <td>Discounted</td>
-       <td>&mdash;</td>
-       <td>$295</td>
+       {% comment %}<td>&mdash;</td>{% endcomment %}
+       <td>$299</td>
        <td>Students, those on a lower income, or otherwise those for whom paying the full individual rate presents a financial hardship</td>
       </tr>
       <tr>
        <td>Tutorials</td>
-       <td>&mdash;</td>
-       <td>$195</td>
+       {% comment %}<td>&mdash;</td>{% endcomment %}
+       <td>$199</td>
        <td>Per tutorial</td>
       </tr>
       <tr>
        <td>Sprints</td>
-       <td>&mdash;</td>
+       {% comment %}<td>&mdash;</td>{% endcomment %}
        <td>Free</td>
        <td>Please register so we can feed you</td>
       </tr>

--- a/_pages/tickets.html
+++ b/_pages/tickets.html
@@ -75,7 +75,7 @@ description: Information about buying tickets to DjangoCon US
        <tr>
         <td>Online Only - Corporate</td>
         {% comment %}<td>&mdash;</td>{% endcomment %}
-        <td>$999</td>
+        <td>$299</td>
         <td><div>Companies with more than 5 employees</div><div>(including state agencies and nonprofits, if able)</div></td>
        </tr>
       <tr>

--- a/_pages/tickets.html
+++ b/_pages/tickets.html
@@ -67,6 +67,18 @@ description: Information about buying tickets to DjangoCon US
        <td><div>Companies with more than 5 employees</div><div>(including state agencies and nonprofits, if able)</div></td>
       </tr>
       <tr>
+        <td>Online Only - Individual</td>
+        {% comment %}<td>&mdash;</td>{% endcomment %}
+        <td>$149</td>
+        <td><div>People paying their own way</div><div>Companies with 5 or fewer employees</div></td>
+       </tr>
+       <tr>
+        <td>Online Only - Corporate</td>
+        {% comment %}<td>&mdash;</td>{% endcomment %}
+        <td>$999</td>
+        <td><div>Companies with more than 5 employees</div><div>(including state agencies and nonprofits, if able)</div></td>
+       </tr>
+      <tr>
        <td>Patron</td>
        {% comment %}<td>&mdash;</td>{% endcomment %}
        <td>$999</td>
@@ -84,6 +96,12 @@ description: Information about buying tickets to DjangoCon US
        <td>$299</td>
        <td>Students, those on a lower income, or otherwise those for whom paying the full individual rate presents a financial hardship</td>
       </tr>
+      <tr>
+        <td>Online Only - Discounted</td>
+        {% comment %}<td>&mdash;</td>{% endcomment %}
+        <td>$99</td>
+        <td>Students, those on a lower income, or otherwise those for whom paying the full individual rate presents a financial hardship</td>
+       </tr>
       <tr>
        <td>Tutorials</td>
        {% comment %}<td>&mdash;</td>{% endcomment %}

--- a/_pages/tutorials.html
+++ b/_pages/tutorials.html
@@ -13,7 +13,7 @@ title: Tutorials Schedule
   <div class="row column">
     <h2 class="day">Tutorials: Sunday, October 16</h2>
     <p class="lead">
-      Tutorials are a separate registration and are $195 per session. {% comment %}Buy <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell out!{% endcomment %}
+      Tutorials are a separate registration and are $195 per session. Buy <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell out!
     </p>
     <ul class="schedule">
       {% for post in site.schedule %}

--- a/_pages/tutorials.html
+++ b/_pages/tutorials.html
@@ -13,7 +13,7 @@ title: Tutorials Schedule
   <div class="row column">
     <h2 class="day">Tutorials: Sunday, October 16</h2>
     <p class="lead">
-      Tutorials are a separate registration and are $195 per session. Buy <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell out!
+      Tutorials are a separate registration and are $199 per session. Buy <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell out!
     </p>
     <ul class="schedule">
       {% for post in site.schedule %}

--- a/_pages/why-djangocon-us.html
+++ b/_pages/why-djangocon-us.html
@@ -187,7 +187,7 @@ description: |
         alt="A graduation cap"
         class="media-icon">
       <h3 class="tutorials-block-heading">Looking for something hands-on?</h3>
-      <p>Tutorials are only <strong>$195 each</strong> and are a great way for teams to deep-dive new concepts.</p>
+      <p>Tutorials are only <strong>$19 each</strong> and are a great way for teams to deep-dive new concepts.</p>
     </div>
     <div class="column column-block">
       <section class="event boxed" data-equalizer-watch>

--- a/_pages/why-djangocon-us.html
+++ b/_pages/why-djangocon-us.html
@@ -187,7 +187,7 @@ description: |
         alt="A graduation cap"
         class="media-icon">
       <h3 class="tutorials-block-heading">Looking for something hands-on?</h3>
-      <p>Tutorials are only <strong>$19 each</strong> and are a great way for teams to deep-dive new concepts.</p>
+      <p>Tutorials are only <strong>$199 each</strong> and are a great way for teams to deep-dive new concepts.</p>
     </div>
     <div class="column column-block">
       <section class="event boxed" data-equalizer-watch>

--- a/_posts/2022-05-10-announcing-djangocon-us-2022.md
+++ b/_posts/2022-05-10-announcing-djangocon-us-2022.md
@@ -12,12 +12,12 @@ It looks amazing!
 
 The conference will be from Sunday, October 16th, through Friday, October 21st, 2022.
 
-- October 16: Tutorials ($195 per tutorial)
+- October 16: Tutorials ($199 per tutorial)
 - October 17, 18, &amp; 19: Talks
 - October 20 &amp; 21: Sprints
 
 This year we will be returning to the [Marriott of Mission Valley](https://2022.djangocon.us/venue/) in San Diego, CA.
-{% comment %}Tickets are [on sale now](https://ti.to/defna/djangocon-us-2022){% endcomment %} Tickets will be on sale soon, and our [hotel block is open](https://www.marriott.com/events/start.mi?id=1642551494496&key=GRP).
+Tickets are [on sale now](https://ti.to/defna/djangocon-us-2022){% comment %}Tickets will be on sale soon{% endcomment %}, and our [hotel block is open](https://www.marriott.com/events/start.mi?id=1642551494496&key=GRP).
 {% comment %}We sold out in previous years, so please take advantage of our early bird pricing!{% endcomment %}
 
 We are accepting [opportunity grant](https://2022.djangocon.us/opportunity-grants/) applications through end of day June 10th, 2022 [AoE](https://time.is/compare/0000_10_June_2022_in_Anywhere_on_Earth).


### PR DESCRIPTION
Changes proposed in this PR:

- Enables the buy tickets button everywhere it's been commented out
- Updates prices from $x95 to $x99
- Hides the early bird ticket column
- Adds online-only pricing
