### PR TITLE
Adds the ability to have sponsors link to hiring pages

### DIFF
--- a/_pages/sponsors.html
+++ b/_pages/sponsors.html
@@ -54,7 +54,10 @@ description: DjangoCon US is only possible through the support of various organi
               <h3 class="partner-name"><a href="{{ sponsor.url_target }}" rel="sponsored">{{ sponsor.name }}</a></h3>
               {% capture sponsor_description %}{{ sponsor.description }}{: .partner-description }{% endcapture %}
               {{ sponsor_description | markdownify }}
-              {% if sponsor.hiring %}<a href="/job-board/" class="button">{{ sponsor.name }} is hiring!</a>{% endif %}
+
+              {% if sponsor.hiring_url %}
+                <a href="{{ sponsor.hiring_url }}" class="button" rel="noopener">{{ sponsor.name }} is hiring!</a>
+              {% endif %}
             </div>
           </div>
         {% endunless %}

--- a/_sponsors/2022-06-21-lincolnloop.md
+++ b/_sponsors/2022-06-21-lincolnloop.md
@@ -10,5 +10,5 @@ url_target: "https://lincolnloop.com/"
 url_friendly: "lincolnloop.com"
 description: |
   Lincoln Loop is a full-service software development agency specializing in Python and Django development for web and mobile. Since 2007 our emphasis on quality in an agile environment has helped numerous startups and high-traffic sites grow their businesses. In addition to rock solid Python powered backends, Lincoln Loop provides user experience, deployment, and real-time application development with JavaScript.
-hiring: false
+hiring_url: "https://lincolnloop.com/careers/"
 ---


### PR DESCRIPTION
Changes proposed in this PR:

- Adds a link to LincolnLoop's hiring page
- Removes the job board link


## Screenshot
![Screenshot from 2022-06-21 20-09-47](https://user-images.githubusercontent.com/185043/174935241-375099f2-7923-48b7-80a1-0991639182c1.png)

