### PR TITLE
📰 Annouce Talk & Tutorial Lineup

### DIFF
--- a/_posts/2022-07-08-announcing-lineup.md
+++ b/_posts/2022-07-08-announcing-lineup.md
@@ -42,7 +42,6 @@ _All talks will be available live for those with online-only tickets. They will 
 - Django Migrations: Pitfalls and Solutions (Benjamin "Zags" Zagorsky)
 - Explaining EXPLAIN: A dive into PostgreSQL's EXPLAIN plans (Richard Yen)
 - Fighting Climate Change with Django (Erin Mullaney)
-- Handling Django issues in highly concurrent & scale environment (Tarun Garg)
 - Hidden gems of Django Admin (Maxim Danilov)
 - Home on the range with Django - getting comfortable with ranges and range fields (Jack Linke) 
 - How to turn your Website into an App (and why maybe you shouldn't!) (Russell Keith-Magee)

--- a/_posts/2022-07-08-announcing-lineup.md
+++ b/_posts/2022-07-08-announcing-lineup.md
@@ -64,6 +64,6 @@ _All talks will be available live for those with online-only tickets. They will 
 - Why I Didn't Start With Django (Mario Munoz)
 - Why large Django projects need a data (prefetching) layer (Flávio Juvenal)
 - You Don't Need Containers to Run Django in Production (Eduardo Felipe Castegnaro)
-- Your First Deployment Shouldn't Be So Hard! ()
+- Your First Deployment Shouldn't Be So Hard! (Eric Matthes)
 
 If you’d like to check out these talks and more, [tickets are still on sale]({{site.ticket_link}}). Tutorials (sold separately from conference registration) are $195 each, and we will have the schedule for those up soon. We hope to see you in San Diego! ⛵

--- a/_posts/2022-07-08-announcing-lineup.md
+++ b/_posts/2022-07-08-announcing-lineup.md
@@ -35,7 +35,7 @@ _All talks will be available live for those with online-only tickets. They will 
 - Astrodigenous: an online portal for Indigenous sky-knowledge resources in Canada (Heidi White)
 - Async Django: The practical guide you've been **awaiting** for. (Carlton Gibson)
 - AyudaPy.org: From Weekend Project to Key Civic Movement During the Pandemic (Marcelo Elizeche Landó)
-- Building a dev-focused learner management system with Django (Sheena)
+- Building a dev-focused learner management system with Django (Sheena O'Connell)
 - Building Microservice Architecture for scale with Django (Syed Ansab Waqar Gillani, Syed Muhammad Dawoud Sheraz Ali)
 - Django from queryset to serialization (Iuri de Silvio)
 - Django Logging Demystified (Lee Trout)

--- a/_posts/2022-07-08-announcing-lineup.md
+++ b/_posts/2022-07-08-announcing-lineup.md
@@ -1,0 +1,69 @@
+---
+author: DjangoCon US Organizers
+category: General
+date: 2022-07-08 06:00:00
+layout: post
+image: /static/img/blog/speaking.jpg
+post_photo_url: /static/img/blog/speaking.jpg
+post_photo_alt: "Speaker addressing a crowd at DjangoCon US 2019 in San Diego"
+title: "Announcing Our DjangoCon US 2022 Talks!" 
+---
+
+We are delighted to present our tutorial and talk lineup! 
+
+The final talk and tutorial schedule will be announced soon. If you haven’t purchased your ticket yet, [they’re still on sale]({{site.ticket_link}}).
+
+Congratulations to the presenters of the tutorials and talks below!
+
+## Tutorials 
+
+_Tutorials will not be available online; you must attend in person._ 
+
+- “It doesn’t work” - A Djangonaut’s debugging tool kit (Tim Schilling)
+- A detailed review for using Django, Channels, and HTMX to create dynamic and interactive web sites (Ken Whitesell)
+- Build a production ready GraphQL API using Python (Patrick Arminio)
+- Effective end-to-end testing for Django (Ed Rivas)
+- Parlez-vous Django? Internationalization with Wagtail (Meagen Voss)
+- Using Django for serving REST APIs with permission control and customizing the default admin panel (Kuldeep Pisda)
+
+## Talks 
+
+_All talks will be available live for those with online-only tickets. They will be posted to YouTube after the conference for free._
+
+- A Management Layer for Scalable, Multitenant Django (Addison Hardy, James Ray)
+- A pythonic full-text search (Paolo Melchiorre)
+- Astrodigenous: an online portal for Indigenous sky-knowledge resources in Canada (Heidi White)
+- Async Django: The practical guide you've been **awaiting** for. (Carlton Gibson)
+- AyudaPy.org: From Weekend Project to Key Civic Movement During the Pandemic (Marcelo Elizeche Landó)
+- Building a dev-focused learner management system with Django (Sheena)
+- Building Microservice Architecture for scale with Django (Syed Ansab Waqar Gillani, Syed Muhammad Dawoud Sheraz Ali)
+- Django from queryset to serialization (Iuri de Silvio)
+- Django Logging Demystified (Lee Trout)
+- Django Migrations: Pitfalls and Solutions (Benjamin "Zags" Zagorsky)
+- Explaining EXPLAIN: A dive into PostgreSQL's EXPLAIN plans (Richard Yen)
+- Fighting Climate Change with Django (Erin Mullaney)
+- Handling Django issues in highly concurrent & scale environment (Tarun Garg)
+- Hidden gems of Django Admin (Maxim Danilov)
+- Home on the range with Django - getting comfortable with ranges and range fields (Jack Linke) 
+- How to turn your Website into an App (and why maybe you shouldn't!) (Russell Keith-Magee)
+- I Can't Believe It's Not Real Data! An Introduction into Synthetic Data (Mason Egger)
+- Integrating React in the Django way! (Jiten Sidhpura)
+- Just enough ops for developers (Peter Baumgartner)
+- Keeping track of architectural-ish decisions in a sustainable way (Juan Saavedra)
+- Lint All the Things! (Luke Lee)
+- Massively increase your productivity on personal projects with comprehensive documentation and automated tests (Simon Willison)
+- Method Resolution Order (MRO) in Python (Sanyam Khurana)
+- Nurturing a "Legacy" Codebase (Karen Tracey)
+- Predict Lightning Strikes using Django and AWS (Calvin Hendryx-Parker)
+- Scheming with CSRF: When platforms manage to break things. (Katie McLaughlin)
+- The Best of Both Worlds: Using Vue and Django Together in a Hybrid Approach (Brent O'Connor, Joshua Weaver)
+- The Django Admin Is Your Oyster: Let’s Extend Its Functionality (Adrienne Franke)
+- The Django Jigsaw Puzzle: Aligning All the Pieces (Will Vincent)
+- Tips and tricks for optimizing Django response times (Carmela Beiro)
+- War Stories: Scaling Django (David Foster)
+- Why I Didn't Start With Django (Mario Munoz)
+- Why large Django projects need a data (prefetching) layer (Flávio Juvenal)
+- You Don't Need Containers to Run Django in Production (Eduardo Felipe Castegnaro)
+- Your First Deployment Shouldn't Be So Hard! ()
+
+If you’d like to check out these talks and more, [tickets are still on sale]({{site.ticket_link}}). Tutorials (sold separately from conference registration) are $195 each, and we will have the schedule for those up soon. We hope to see you in San Diego! ⛵


### PR DESCRIPTION
Changes proposed in this PR:

- Adds blog post to announce talks and tutorials. 
