### PR TITLE
Add TwoRock software as a Bronze Sponsor

### DIFF
--- a/_sponsors/2022-07-08-tworocksoftware.md
+++ b/_sponsors/2022-07-08-tworocksoftware.md
@@ -1,0 +1,14 @@
+---
+layout: base
+
+hidden: false
+level: "Bronze"
+name: "Two Rock Software"
+logo: "/static/img/sponsors/Two-Rock-Software-Logo.svg"
+logo_orientation: "landscape"
+url_target: "https://tworock.io"
+url_friendly: "tworock.io"
+description: |
+  Two Rock Software is a friendly Django shop that focuses on developing custom solutions for humans. We enjoy collaborating at every level of a project from conception and brainstorming to launch and beyond. Our clients include a range of small to midsize businesses and nonprofits. Contact us to discover new ways to achieve growth and efficiency.
+hiring_url: "https://tworock.io/jobs/"
+---


### PR DESCRIPTION
- This add TwoRock as a Bronze level sponsor with a hiring link

## Screenshot
![Screenshot 2022-07-08 at 16-00-58 DjangoCon US](https://user-images.githubusercontent.com/185043/178080113-b162ae45-9974-43bf-9721-9d4fabcf43d7.png)

