### PR TITLE
✏️ Remove leading @ from twitter handles

### DIFF
--- a/_presenters/andrej-baranovskij.md
+++ b/_presenters/andrej-baranovskij.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 name: Andrej Baranovskij
 photo_url: https://pretalx.com/media/avatars/profile_GNLZv9i.png
-twitter: '@andrejusb'
+twitter: andrejusb
 website: null
 ---
 

--- a/_presenters/carlton-gibson.md
+++ b/_presenters/carlton-gibson.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 name: Carlton Gibson
 photo_url: null
-twitter: '@carltongibson'
+twitter: carltongibson
 website: null
 ---
 

--- a/_presenters/erin-mullaney.md
+++ b/_presenters/erin-mullaney.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 name: Erin Mullaney
 photo_url: null
-twitter: '@_erin_rachel'
+twitter: _erin_rachel
 website: null
 ---
 

--- a/_presenters/heidi-white.md
+++ b/_presenters/heidi-white.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 name: Heidi White
 photo_url: null
-twitter: '@heidiwhite'
+twitter: heidiwhite
 website: null
 ---
 

--- a/_presenters/marcelo-elizeche-lando.md
+++ b/_presenters/marcelo-elizeche-lando.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 name: Marcelo Elizeche Landó
 photo_url: https://pretalx.com/media/avatars/UOgi3yyv_400x400_FEnriAu.jpg
-twitter: '@melizeche'
+twitter: melizeche
 website: null
 ---
 

--- a/_presenters/mario-munoz.md
+++ b/_presenters/mario-munoz.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 name: Mario Munoz
 photo_url: https://pretalx.com/media/avatars/mm-profile-sq_kzlldqC.png
-twitter: '@PythonByNight'
+twitter: PythonByNight
 website: null
 ---
 

--- a/_presenters/maxim-danilov.md
+++ b/_presenters/maxim-danilov.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 name: Maxim Danilov
 photo_url: null
-twitter: '@danilovmy'
+twitter: danilovmy
 website: null
 ---
 

--- a/_presenters/meagen-voss.md
+++ b/_presenters/meagen-voss.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 name: Meagen Voss
 photo_url: null
-twitter: '@meagenvoss'
+twitter: meagenvosss
 website: null
 ---
 


### PR DESCRIPTION
Changes proposed in this PR:

- Drops leading `@` from speakers' twitter handles so as not to break the template

