### PR TITLE
Switch Presenter OG links to be generated dynamically with 11ty's screenshot api

### DIFF
--- a/_schedule/sprints/2022-10-20-09-00-getting-started-contributing-to-django.md
+++ b/_schedule/sprints/2022-10-20-09-00-getting-started-contributing-to-django.md
@@ -5,6 +5,7 @@ accepted: true
 category: sprints
 date: 2022-10-20 09:00:00-07:00
 end_date: 2022-10-20 12:00:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcarlton-gibson/opengraph/
 layout: session-details
 permalink: /sprints/getting-started-contributing-to-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-09-00-orientation-and-welcome.md
+++ b/_schedule/talks/2022-10-17-09-00-orientation-and-welcome.md
@@ -5,7 +5,7 @@ category: talk
 date: 2022-10-17 09:00:00-07:00
 difficulty: All
 end_date: 2022-10-17 09:30:00-07:00
-image: /static/img/social/presenters/kojo-idrissa.png
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkojo-idrissa/opengraph/
 layout: session-details
 permalink: /talks/orientation-and-welcome/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-10-40-t2-working-with-time-series-data-using-and.md
+++ b/_schedule/talks/2022-10-17-10-40-t2-working-with-time-series-data-using-and.md
@@ -11,6 +11,7 @@ accepted: true
 category: talks
 date: 2022-10-17 10:40:00-07:00
 end_date: 2022-10-17 11:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fjoaquin-scocozza/opengraph/
 layout: session-details
 permalink: /talks/working-with-time-series-data-using-and/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-11-10-t0-the-django-admin-is-your-oyster-lets-its.md
+++ b/_schedule/talks/2022-10-17-11-10-t0-the-django-admin-is-your-oyster-lets-its.md
@@ -12,6 +12,7 @@ accepted: true
 category: talks
 date: 2022-10-17 11:10:00-07:00
 end_date: 2022-10-17 11:55:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fadrienne-franke/opengraph/
 layout: session-details
 permalink: /talks/the-django-admin-is-your-oyster-lets-its/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-11-10-t1-django-logging-demystified.md
+++ b/_schedule/talks/2022-10-17-11-10-t1-django-logging-demystified.md
@@ -6,6 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-17 11:10:00-07:00
 end_date: 2022-10-17 11:55:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Flee-trout/opengraph/
 layout: session-details
 permalink: /talks/django-logging-demystified/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-00-t0-why-i-didn-t-start-with-django.md
+++ b/_schedule/talks/2022-10-17-12-00-t0-why-i-didn-t-start-with-django.md
@@ -7,6 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-17 12:00:00-07:00
 end_date: 2022-10-17 12:25:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmario-munoz/opengraph/
 layout: session-details
 permalink: /talks/why-i-didn-t-start-with-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-00-t1-i-can-t-believe-it-s-not-real-data-an.md
+++ b/_schedule/talks/2022-10-17-12-00-t1-i-can-t-believe-it-s-not-real-data-an.md
@@ -7,6 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-17 12:00:00-07:00
 end_date: 2022-10-17 12:25:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmason-egger/opengraph/
 layout: session-details
 permalink: /talks/i-can-t-believe-it-s-not-real-data-an/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-17-12-30-t0-lightning-talks.md
@@ -3,6 +3,7 @@ accepted: true
 category: talks
 date: 2022-10-17 12:30:00-07:00
 end_date: 2022-10-17 13:20:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkojo-idrissa/opengraph/
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-13-20-t2-factory-boy-testing-like-a-pro.md
+++ b/_schedule/talks/2022-10-17-13-20-t2-factory-boy-testing-like-a-pro.md
@@ -6,6 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-17 13:20:00-07:00
 end_date: 2022-10-17 14:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcamila-maia/opengraph/
 layout: session-details
 permalink: /talks/factory-boy-testing-like-a-pro/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-00-t0-you-don-t-need-containers-to-run-django.md
+++ b/_schedule/talks/2022-10-17-14-00-t0-you-don-t-need-containers-to-run-django.md
@@ -9,6 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-17 14:00:00-07:00
 end_date: 2022-10-17 14:45:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Feduardo-felipe-castegnaro/opengraph/
 layout: session-details
 permalink: /talks/you-don-t-need-containers-to-run-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-00-t1-building-a-dev-focused-learner-system.md
+++ b/_schedule/talks/2022-10-17-14-00-t1-building-a-dev-focused-learner-system.md
@@ -11,6 +11,7 @@ accepted: true
 category: talks
 date: 2022-10-17 14:00:00-07:00
 end_date: 2022-10-17 14:45:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fsheena-oconnell/opengraph/
 layout: session-details
 permalink: /talks/building-a-dev-focused-learner-system/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-50-t0-predict-lightning-strikes-using-django.md
+++ b/_schedule/talks/2022-10-17-14-50-t0-predict-lightning-strikes-using-django.md
@@ -6,6 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-17 14:50:00-07:00
 end_date: 2022-10-17 15:15:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcalvin-hendryx-parker/opengraph/
 layout: session-details
 permalink: /talks/predict-lightning-strikes-using-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-50-t1-the-best-of-both-worlds-using-vue-and-in.md
+++ b/_schedule/talks/2022-10-17-14-50-t1-the-best-of-both-worlds-using-vue-and-in.md
@@ -8,6 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-17 14:50:00-07:00
 end_date: 2022-10-17 15:15:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fbrent-o-connor/opengraph/
 layout: session-details
 permalink: /talks/the-best-of-both-worlds-using-vue-and-in/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-20-t2-a-tour-of-the-sql-server-backend-for.md
+++ b/_schedule/talks/2022-10-17-15-20-t2-a-tour-of-the-sql-server-backend-for.md
@@ -9,6 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-17 15:20:00-07:00
 end_date: 2022-10-17 15:45:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fdrew-skwiers-koballa/opengraph/
 layout: session-details
 permalink: /talks/a-tour-of-the-sql-server-backend-for/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-50-t0-the-django-jigsaw-puzzle-aligning-all.md
+++ b/_schedule/talks/2022-10-17-15-50-t0-the-django-jigsaw-puzzle-aligning-all.md
@@ -4,6 +4,7 @@ accepted: true
 category: talks
 date: 2022-10-17 15:50:00-07:00
 end_date: 2022-10-17 16:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fwill-vincent/opengraph/
 layout: session-details
 permalink: /talks/the-django-jigsaw-puzzle-aligning-all/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-50-t1-war-stories-scaling-django.md
+++ b/_schedule/talks/2022-10-17-15-50-t1-war-stories-scaling-django.md
@@ -5,6 +5,7 @@ accepted: true
 category: talks
 date: 2022-10-17 15:50:00-07:00
 end_date: 2022-10-17 16:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fdavid-foster/opengraph/
 layout: session-details
 permalink: /talks/war-stories-scaling-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-16-40-t0-nurturing-a-legacy-codebase.md
+++ b/_schedule/talks/2022-10-17-16-40-t0-nurturing-a-legacy-codebase.md
@@ -8,6 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-17 16:40:00-07:00
 end_date: 2022-10-17 17:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkaren-tracey/opengraph/
 layout: session-details
 permalink: /talks/nurturing-a-legacy-codebase/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-16-40-t1-massively-increase-your-productivity-on.md
+++ b/_schedule/talks/2022-10-17-16-40-t1-massively-increase-your-productivity-on.md
@@ -9,6 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-17 16:40:00-07:00
 end_date: 2022-10-17 17:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fsimon-willison/opengraph/
 layout: session-details
 permalink: /talks/massively-increase-your-productivity-on/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-10-t0-fighting-climate-change-with-django.md
+++ b/_schedule/talks/2022-10-17-17-10-t0-fighting-climate-change-with-django.md
@@ -9,6 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-17 17:10:00-07:00
 end_date: 2022-10-17 17:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Ferin-mullaney/opengraph/
 layout: session-details
 permalink: /talks/fighting-climate-change-with-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-10-t1-django-from-queryset-to-serialization.md
+++ b/_schedule/talks/2022-10-17-17-10-t1-django-from-queryset-to-serialization.md
@@ -7,6 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-17 17:10:00-07:00
 end_date: 2022-10-17 17:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fiuri-de-silvio/opengraph/
 layout: session-details
 permalink: /talks/django-from-queryset-to-serialization/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-40-t2-how-to-be-a-postgres-dba-in-a-pinch.md
+++ b/_schedule/talks/2022-10-17-17-40-t2-how-to-be-a-postgres-dba-in-a-pinch.md
@@ -8,6 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-17 17:40:00-07:00
 end_date: 2022-10-17 18:25:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Felizabeth-garrett-christensen/opengraph/
 layout: session-details
 permalink: /talks/how-to-be-a-postgres-dba-in-a-pinch/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-10-40-t2-documenting-django-code-in-2022.md
+++ b/_schedule/talks/2022-10-18-10-40-t2-documenting-django-code-in-2022.md
@@ -11,6 +11,7 @@ accepted: true
 category: talks
 date: 2022-10-18 10:40:00-07:00
 end_date: 2022-10-18 11:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Feric-holscher/opengraph/
 layout: session-details
 permalink: /talks/documenting-django-code-in-2022/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-11-10-t0-ayudapy-org-from-weekend-project-to-key.md
+++ b/_schedule/talks/2022-10-18-11-10-t0-ayudapy-org-from-weekend-project-to-key.md
@@ -5,6 +5,7 @@ accepted: true
 category: talks
 date: 2022-10-18 11:10:00-07:00
 end_date: 2022-10-18 11:55:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmarcelo-elizeche-lando/opengraph/
 layout: session-details
 permalink: /talks/ayudapy-org-from-weekend-project-to-key/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-11-10-t1-keeping-track-of-architectural-ish-in-a.md
+++ b/_schedule/talks/2022-10-18-11-10-t1-keeping-track-of-architectural-ish-in-a.md
@@ -12,6 +12,7 @@ accepted: true
 category: talks
 date: 2022-10-18 11:10:00-07:00
 end_date: 2022-10-18 11:55:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fjuan-saavedra/opengraph/
 layout: session-details
 permalink: /talks/keeping-track-of-architectural-ish-in-a/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-00-t0-scheming-with-csrf-when-platforms-manage.md
+++ b/_schedule/talks/2022-10-18-12-00-t0-scheming-with-csrf-when-platforms-manage.md
@@ -7,6 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-18 12:00:00-07:00
 end_date: 2022-10-18 12:25:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkatie-mclaughlin/opengraph/
 layout: session-details
 permalink: /talks/scheming-with-csrf-when-platforms-manage/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-00-t1-django-migrations-pitfalls-and-solutions.md
+++ b/_schedule/talks/2022-10-18-12-00-t1-django-migrations-pitfalls-and-solutions.md
@@ -15,6 +15,7 @@ accepted: true
 category: talks
 date: 2022-10-18 12:00:00-07:00
 end_date: 2022-10-18 12:25:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fbenjamin-zags-zagorsky/opengraph/
 layout: session-details
 permalink: /talks/django-migrations-pitfalls-and-solutions/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-18-12-30-t0-lightning-talks.md
@@ -3,6 +3,7 @@ accepted: true
 category: talks
 date: 2022-10-18 12:30:00-07:00
 end_date: 2022-10-18 13:20:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkojo-idrissa/opengraph/
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-13-20-t2-type-checking-your-django-code-with-and.md
+++ b/_schedule/talks/2022-10-18-13-20-t2-type-checking-your-django-code-with-and.md
@@ -13,6 +13,7 @@ accepted: true
 category: talks
 date: 2022-10-18 13:20:00-07:00
 end_date: 2022-10-18 14:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkyle-bebak/opengraph/
 layout: session-details
 permalink: /talks/type-checking-your-django-code-with-and/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-00-t0-explaining-explain-a-dive-into-s-explain.md
+++ b/_schedule/talks/2022-10-18-14-00-t0-explaining-explain-a-dive-into-s-explain.md
@@ -4,6 +4,7 @@ accepted: true
 category: talks
 date: 2022-10-18 14:00:00-07:00
 end_date: 2022-10-18 14:45:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Frichard-yen/opengraph/
 layout: session-details
 permalink: /talks/explaining-explain-a-dive-into-s-explain/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-00-t1-building-microservice-architecture-for.md
+++ b/_schedule/talks/2022-10-18-14-00-t1-building-microservice-architecture-for.md
@@ -6,6 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-18 14:00:00-07:00
 end_date: 2022-10-18 14:45:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fsyed-ansab-waqar-gillani/opengraph/
 layout: session-details
 permalink: /talks/building-microservice-architecture-for/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-50-t0-lint-all-the-things.md
+++ b/_schedule/talks/2022-10-18-14-50-t0-lint-all-the-things.md
@@ -7,6 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-18 14:50:00-07:00
 end_date: 2022-10-18 15:15:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fluke-lee/opengraph/
 layout: session-details
 permalink: /talks/lint-all-the-things/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-50-t1-method-resolution-order-mro-in-python.md
+++ b/_schedule/talks/2022-10-18-14-50-t1-method-resolution-order-mro-in-python.md
@@ -7,6 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-18 14:50:00-07:00
 end_date: 2022-10-18 15:15:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fsanyam-khurana/opengraph/
 layout: session-details
 permalink: /talks/method-resolution-order-mro-in-python/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-20-t2-lessons-learned-teaching-undergraduate-a.md
+++ b/_schedule/talks/2022-10-18-15-20-t2-lessons-learned-teaching-undergraduate-a.md
@@ -16,6 +16,7 @@ accepted: true
 category: talks
 date: 2022-10-18 15:20:00-07:00
 end_date: 2022-10-18 15:45:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fandrew-mshar/opengraph/
 layout: session-details
 permalink: /talks/lessons-learned-teaching-undergraduate-a/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-50-t0-just-enough-ops-for-developers.md
+++ b/_schedule/talks/2022-10-18-15-50-t0-just-enough-ops-for-developers.md
@@ -15,6 +15,7 @@ accepted: true
 category: talks
 date: 2022-10-18 15:50:00-07:00
 end_date: 2022-10-18 16:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fpeter-baumgartner/opengraph/
 layout: session-details
 permalink: /talks/just-enough-ops-for-developers/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-50-t1-a-management-layer-for-scalable-django.md
+++ b/_schedule/talks/2022-10-18-15-50-t1-a-management-layer-for-scalable-django.md
@@ -10,6 +10,7 @@ accepted: true
 category: talks
 date: 2022-10-18 15:50:00-07:00
 end_date: 2022-10-18 16:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Faddison-hardy/opengraph/
 layout: session-details
 permalink: /talks/a-management-layer-for-scalable-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-16-40-t0-your-first-deployment-shouldn-t-be-so.md
+++ b/_schedule/talks/2022-10-18-16-40-t0-your-first-deployment-shouldn-t-be-so.md
@@ -8,6 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-18 16:40:00-07:00
 end_date: 2022-10-18 17:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Feric-matthes/opengraph/
 layout: session-details
 permalink: /talks/your-first-deployment-shouldn-t-be-so/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-16-40-t1-astrodigenous-an-online-portal-for-sky.md
+++ b/_schedule/talks/2022-10-18-16-40-t1-astrodigenous-an-online-portal-for-sky.md
@@ -21,6 +21,7 @@ accepted: true
 category: talks
 date: 2022-10-18 16:40:00-07:00
 end_date: 2022-10-18 17:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fheidi-white/opengraph/
 layout: session-details
 permalink: /talks/astrodigenous-an-online-portal-for-sky/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-17-10-t0-tips-and-tricks-for-optimizing-django.md
+++ b/_schedule/talks/2022-10-18-17-10-t0-tips-and-tricks-for-optimizing-django.md
@@ -12,6 +12,7 @@ accepted: true
 category: talks
 date: 2022-10-18 17:10:00-07:00
 end_date: 2022-10-18 17:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcarmela-beiro/opengraph/
 layout: session-details
 permalink: /talks/tips-and-tricks-for-optimizing-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-17-10-t1-integrating-react-in-the-django-way.md
+++ b/_schedule/talks/2022-10-18-17-10-t1-integrating-react-in-the-django-way.md
@@ -9,6 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-18 17:10:00-07:00
 end_date: 2022-10-18 17:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fjiten-sidhpura/opengraph/
 layout: session-details
 permalink: /talks/integrating-react-in-the-django-way/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-10-40-t2-herding-your-database-queries-diagnosing.md
+++ b/_schedule/talks/2022-10-19-10-40-t2-herding-your-database-queries-diagnosing.md
@@ -8,6 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-19 10:40:00-07:00
 end_date: 2022-10-19 11:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Filya-bass/opengraph/
 layout: session-details
 permalink: /talks/herding-your-database-queries-diagnosing/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-11-10-t0-hidden-gems-of-django-admin.md
+++ b/_schedule/talks/2022-10-19-11-10-t0-hidden-gems-of-django-admin.md
@@ -5,6 +5,7 @@ accepted: true
 category: talks
 date: 2022-10-19 11:10:00-07:00
 end_date: 2022-10-19 11:55:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmaxim-danilov/opengraph/
 layout: session-details
 permalink: /talks/hidden-gems-of-django-admin/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-12-00-t0-async-django-the-practical-guide-you-ve.md
+++ b/_schedule/talks/2022-10-19-12-00-t0-async-django-the-practical-guide-you-ve.md
@@ -6,6 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-19 12:00:00-07:00
 end_date: 2022-10-19 12:25:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcarlton-gibson/opengraph/
 layout: session-details
 permalink: /talks/async-django-the-practical-guide-you-ve/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-19-12-30-t0-lightning-talks.md
@@ -3,6 +3,7 @@ accepted: true
 category: talks
 date: 2022-10-19 12:30:00-07:00
 end_date: 2022-10-19 13:20:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkojo-idrissa/opengraph/
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-13-20-t2-modern-apps-with-django-htmx-tailwind-js.md
+++ b/_schedule/talks/2022-10-19-13-20-t2-modern-apps-with-django-htmx-tailwind-js.md
@@ -9,6 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-19 13:20:00-07:00
 end_date: 2022-10-19 14:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fandrej-baranovskij/opengraph/
 layout: session-details
 permalink: /talks/modern-apps-with-django-htmx-tailwind-js/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-14-00-t0-why-large-django-projects-need-a-data.md
+++ b/_schedule/talks/2022-10-19-14-00-t0-why-large-django-projects-need-a-data.md
@@ -10,6 +10,7 @@ accepted: true
 category: talks
 date: 2022-10-19 14:00:00-07:00
 end_date: 2022-10-19 14:45:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fflavio-juvenal/opengraph/
 layout: session-details
 permalink: /talks/why-large-django-projects-need-a-data/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-14-50-t0-a-pythonic-full-text-search.md
+++ b/_schedule/talks/2022-10-19-14-50-t0-a-pythonic-full-text-search.md
@@ -7,6 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-19 14:50:00-07:00
 end_date: 2022-10-19 15:15:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fpaolo-melchiorre/opengraph/
 layout: session-details
 permalink: /talks/a-pythonic-full-text-search/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-15-20-t2-the-software-supply-chain-and-you-how-to.md
+++ b/_schedule/talks/2022-10-19-15-20-t2-the-software-supply-chain-and-you-how-to.md
@@ -7,6 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-19 15:20:00-07:00
 end_date: 2022-10-19 15:45:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Flisa-tagliaferri/opengraph/
 layout: session-details
 permalink: /talks/the-software-supply-chain-and-you-how-to/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-15-50-t0-home-on-the-range-with-django-getting.md
+++ b/_schedule/talks/2022-10-19-15-50-t0-home-on-the-range-with-django-getting.md
@@ -9,6 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-19 15:50:00-07:00
 end_date: 2022-10-19 16:35:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fjack-linke/opengraph/
 layout: session-details
 permalink: /talks/home-on-the-range-with-django-getting/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-16-40-t0-how-to-turn-your-website-into-an-app-and.md
+++ b/_schedule/talks/2022-10-19-16-40-t0-how-to-turn-your-website-into-an-app-and.md
@@ -6,6 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-19 16:40:00-07:00
 end_date: 2022-10-19 17:05:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Frussell-keith-magee/opengraph/
 layout: session-details
 permalink: /talks/how-to-turn-your-website-into-an-app-and/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t0-effective-end-to-end-testing-for-django.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t0-effective-end-to-end-testing-for-django.md
@@ -8,6 +8,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 09:00:00-07:00
 end_date: 2022-10-16 12:30:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fed-rivas/opengraph/
 layout: session-details
 permalink: /tutorials/effective-end-to-end-testing-for-django/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t1-build-a-production-ready-graphql-api.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t1-build-a-production-ready-graphql-api.md
@@ -6,6 +6,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 09:00:00-07:00
 end_date: 2022-10-16 12:30:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fpatrick-arminio/opengraph/
 layout: session-details
 permalink: /tutorials/build-a-production-ready-graphql-api/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t2-parlez-vous-django-internationalization.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t2-parlez-vous-django-internationalization.md
@@ -16,6 +16,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 09:00:00-07:00
 end_date: 2022-10-16 12:30:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmeagen-voss/opengraph/
 layout: session-details
 permalink: /tutorials/parlez-vous-django-internationalization/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t0-it-doesnt-work-a-djangonauts-debugging.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t0-it-doesnt-work-a-djangonauts-debugging.md
@@ -7,6 +7,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 13:30:00-07:00
 end_date: 2022-10-16 17:00:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Ftim-schilling/opengraph/
 layout: session-details
 permalink: /tutorials/it-doesnt-work-a-djangonauts-debugging/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t1-using-django-for-serving-rest-apis-with.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t1-using-django-for-serving-rest-apis-with.md
@@ -9,6 +9,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 13:30:00-07:00
 end_date: 2022-10-16 17:00:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkuldeep-pisda/opengraph/
 layout: session-details
 permalink: /tutorials/using-django-for-serving-rest-apis-with/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t2-a-detailed-review-for-using-django-and.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t2-a-detailed-review-for-using-django-and.md
@@ -20,6 +20,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 13:30:00-07:00
 end_date: 2022-10-16 17:00:00-07:00
+image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fken-whitesell/opengraph/
 layout: session-details
 permalink: /tutorials/a-detailed-review-for-using-django-and/
 presenter_slugs:

--- a/bin/process.py
+++ b/bin/process.py
@@ -8,8 +8,10 @@ from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from pathlib import Path
 from pydantic import BaseModel, Field, ValidationError
+from rich import print
 from slugify import slugify
 from typing import List, Optional
+from urllib.parse import quote_plus
 import pytz
 
 CONFERENCE_TZ = pytz.timezone("America/Los_Angeles")
@@ -663,9 +665,9 @@ def process(process_presenters: bool = False, slug_max_length: int = 40):
 
                 if post["presenter_slugs"] and len(post["presenter_slugs"]):
                     presenter_slug = post["presenter_slugs"][0]
-                    post[
-                        "image"
-                    ] = f"/static/img/social/presenters/{presenter_slug}.png"
+                    image_url = f"https://2022.djangocon.us/presenters/{presenter_slug}"
+                    image_url = quote_plus(image_url)
+                    post["image"] = f"https://v1.screenshot.11ty.dev/{image_url}/opengraph/"
 
             if dirty is True:
                 filename.write_text(frontmatter.dumps(post) + "\n")


### PR DESCRIPTION
Inspired by @dryan's tweet: https://twitter.com/dryan/status/1550920114651922432 

This update changed how we build out our OG images for a presenter and builds a screenshot via [11ty.dev](https://www.11ty.dev/docs/services/screenshots/)'s amazing tool. 

Related: #77, #76, #74, #73, #72, #70. 



