### PR TITLE
Fix avatar rounding on schedule

### DIFF
--- a/_src/scss/module/_schedule.scss
+++ b/_src/scss/module/_schedule.scss
@@ -73,7 +73,7 @@
   .avatar {
     aspect-ratio: 1;
     margin: 0 .5em 0 0;
-    max-width: 60px;
+    width: 60px;
     object-fit: cover;
     border-radius: 50%;
     vertical-align: middle;


### PR DESCRIPTION
Changes proposed in this PR:

- Use width over max-width on avatars in the schedule to fix issues with display

This is how it used to look

<img width="218" alt="Screen Shot 2022-07-25 at 2 38 54 PM" src="https://user-images.githubusercontent.com/84750/180850304-22419658-13cb-49ba-bf33-6de44cd938fe.png">

This is how it should look

<img width="363" alt="Screen Shot 2022-07-25 at 2 40 27 PM" src="https://user-images.githubusercontent.com/84750/180850435-061b53b9-e938-46dd-bba0-6ede389249c5.png">

