### PR TITLE
:hammer: Double-escape OG Images

### DIFF
--- a/_schedule/sprints/2022-10-20-09-00-getting-started-contributing-to-django.md
+++ b/_schedule/sprints/2022-10-20-09-00-getting-started-contributing-to-django.md
@@ -5,7 +5,7 @@ accepted: true
 category: sprints
 date: 2022-10-20 09:00:00-07:00
 end_date: 2022-10-20 12:00:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcarlton-gibson/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarlton-gibson/opengraph/
 layout: session-details
 permalink: /sprints/getting-started-contributing-to-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-09-00-orientation-and-welcome.md
+++ b/_schedule/talks/2022-10-17-09-00-orientation-and-welcome.md
@@ -5,7 +5,7 @@ category: talk
 date: 2022-10-17 09:00:00-07:00
 difficulty: All
 end_date: 2022-10-17 09:30:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkojo-idrissa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa/opengraph/
 layout: session-details
 permalink: /talks/orientation-and-welcome/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-10-40-t2-working-with-time-series-data-using-and.md
+++ b/_schedule/talks/2022-10-17-10-40-t2-working-with-time-series-data-using-and.md
@@ -11,7 +11,7 @@ accepted: true
 category: talks
 date: 2022-10-17 10:40:00-07:00
 end_date: 2022-10-17 11:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fjoaquin-scocozza/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjoaquin-scocozza/opengraph/
 layout: session-details
 permalink: /talks/working-with-time-series-data-using-and/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-11-10-t0-the-django-admin-is-your-oyster-lets-its.md
+++ b/_schedule/talks/2022-10-17-11-10-t0-the-django-admin-is-your-oyster-lets-its.md
@@ -12,7 +12,7 @@ accepted: true
 category: talks
 date: 2022-10-17 11:10:00-07:00
 end_date: 2022-10-17 11:55:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fadrienne-franke/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fadrienne-franke/opengraph/
 layout: session-details
 permalink: /talks/the-django-admin-is-your-oyster-lets-its/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-11-10-t1-django-logging-demystified.md
+++ b/_schedule/talks/2022-10-17-11-10-t1-django-logging-demystified.md
@@ -6,7 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-17 11:10:00-07:00
 end_date: 2022-10-17 11:55:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Flee-trout/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Flee-trout/opengraph/
 layout: session-details
 permalink: /talks/django-logging-demystified/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-00-t0-why-i-didn-t-start-with-django.md
+++ b/_schedule/talks/2022-10-17-12-00-t0-why-i-didn-t-start-with-django.md
@@ -7,7 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-17 12:00:00-07:00
 end_date: 2022-10-17 12:25:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmario-munoz/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmario-munoz/opengraph/
 layout: session-details
 permalink: /talks/why-i-didn-t-start-with-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-00-t1-i-can-t-believe-it-s-not-real-data-an.md
+++ b/_schedule/talks/2022-10-17-12-00-t1-i-can-t-believe-it-s-not-real-data-an.md
@@ -7,7 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-17 12:00:00-07:00
 end_date: 2022-10-17 12:25:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmason-egger/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmason-egger/opengraph/
 layout: session-details
 permalink: /talks/i-can-t-believe-it-s-not-real-data-an/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-17-12-30-t0-lightning-talks.md
@@ -3,7 +3,7 @@ accepted: true
 category: talks
 date: 2022-10-17 12:30:00-07:00
 end_date: 2022-10-17 13:20:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkojo-idrissa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa/opengraph/
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-13-20-t2-factory-boy-testing-like-a-pro.md
+++ b/_schedule/talks/2022-10-17-13-20-t2-factory-boy-testing-like-a-pro.md
@@ -6,7 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-17 13:20:00-07:00
 end_date: 2022-10-17 14:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcamila-maia/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcamila-maia/opengraph/
 layout: session-details
 permalink: /talks/factory-boy-testing-like-a-pro/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-00-t0-you-don-t-need-containers-to-run-django.md
+++ b/_schedule/talks/2022-10-17-14-00-t0-you-don-t-need-containers-to-run-django.md
@@ -9,7 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-17 14:00:00-07:00
 end_date: 2022-10-17 14:45:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Feduardo-felipe-castegnaro/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feduardo-felipe-castegnaro/opengraph/
 layout: session-details
 permalink: /talks/you-don-t-need-containers-to-run-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-00-t1-building-a-dev-focused-learner-system.md
+++ b/_schedule/talks/2022-10-17-14-00-t1-building-a-dev-focused-learner-system.md
@@ -11,7 +11,7 @@ accepted: true
 category: talks
 date: 2022-10-17 14:00:00-07:00
 end_date: 2022-10-17 14:45:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fsheena-oconnell/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsheena-oconnell/opengraph/
 layout: session-details
 permalink: /talks/building-a-dev-focused-learner-system/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-50-t0-predict-lightning-strikes-using-django.md
+++ b/_schedule/talks/2022-10-17-14-50-t0-predict-lightning-strikes-using-django.md
@@ -6,7 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-17 14:50:00-07:00
 end_date: 2022-10-17 15:15:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcalvin-hendryx-parker/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcalvin-hendryx-parker/opengraph/
 layout: session-details
 permalink: /talks/predict-lightning-strikes-using-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-50-t1-the-best-of-both-worlds-using-vue-and-in.md
+++ b/_schedule/talks/2022-10-17-14-50-t1-the-best-of-both-worlds-using-vue-and-in.md
@@ -8,7 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-17 14:50:00-07:00
 end_date: 2022-10-17 15:15:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fbrent-o-connor/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fbrent-o-connor/opengraph/
 layout: session-details
 permalink: /talks/the-best-of-both-worlds-using-vue-and-in/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-20-t2-a-tour-of-the-sql-server-backend-for.md
+++ b/_schedule/talks/2022-10-17-15-20-t2-a-tour-of-the-sql-server-backend-for.md
@@ -9,7 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-17 15:20:00-07:00
 end_date: 2022-10-17 15:45:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fdrew-skwiers-koballa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fdrew-skwiers-koballa/opengraph/
 layout: session-details
 permalink: /talks/a-tour-of-the-sql-server-backend-for/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-50-t0-the-django-jigsaw-puzzle-aligning-all.md
+++ b/_schedule/talks/2022-10-17-15-50-t0-the-django-jigsaw-puzzle-aligning-all.md
@@ -4,7 +4,7 @@ accepted: true
 category: talks
 date: 2022-10-17 15:50:00-07:00
 end_date: 2022-10-17 16:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fwill-vincent/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fwill-vincent/opengraph/
 layout: session-details
 permalink: /talks/the-django-jigsaw-puzzle-aligning-all/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-50-t1-war-stories-scaling-django.md
+++ b/_schedule/talks/2022-10-17-15-50-t1-war-stories-scaling-django.md
@@ -5,7 +5,7 @@ accepted: true
 category: talks
 date: 2022-10-17 15:50:00-07:00
 end_date: 2022-10-17 16:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fdavid-foster/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fdavid-foster/opengraph/
 layout: session-details
 permalink: /talks/war-stories-scaling-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-16-40-t0-nurturing-a-legacy-codebase.md
+++ b/_schedule/talks/2022-10-17-16-40-t0-nurturing-a-legacy-codebase.md
@@ -8,7 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-17 16:40:00-07:00
 end_date: 2022-10-17 17:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkaren-tracey/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkaren-tracey/opengraph/
 layout: session-details
 permalink: /talks/nurturing-a-legacy-codebase/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-16-40-t1-massively-increase-your-productivity-on.md
+++ b/_schedule/talks/2022-10-17-16-40-t1-massively-increase-your-productivity-on.md
@@ -9,7 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-17 16:40:00-07:00
 end_date: 2022-10-17 17:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fsimon-willison/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsimon-willison/opengraph/
 layout: session-details
 permalink: /talks/massively-increase-your-productivity-on/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-10-t0-fighting-climate-change-with-django.md
+++ b/_schedule/talks/2022-10-17-17-10-t0-fighting-climate-change-with-django.md
@@ -9,7 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-17 17:10:00-07:00
 end_date: 2022-10-17 17:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Ferin-mullaney/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Ferin-mullaney/opengraph/
 layout: session-details
 permalink: /talks/fighting-climate-change-with-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-10-t1-django-from-queryset-to-serialization.md
+++ b/_schedule/talks/2022-10-17-17-10-t1-django-from-queryset-to-serialization.md
@@ -7,7 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-17 17:10:00-07:00
 end_date: 2022-10-17 17:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fiuri-de-silvio/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fiuri-de-silvio/opengraph/
 layout: session-details
 permalink: /talks/django-from-queryset-to-serialization/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-40-t2-how-to-be-a-postgres-dba-in-a-pinch.md
+++ b/_schedule/talks/2022-10-17-17-40-t2-how-to-be-a-postgres-dba-in-a-pinch.md
@@ -8,7 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-17 17:40:00-07:00
 end_date: 2022-10-17 18:25:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Felizabeth-garrett-christensen/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Felizabeth-garrett-christensen/opengraph/
 layout: session-details
 permalink: /talks/how-to-be-a-postgres-dba-in-a-pinch/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-10-40-t2-documenting-django-code-in-2022.md
+++ b/_schedule/talks/2022-10-18-10-40-t2-documenting-django-code-in-2022.md
@@ -11,7 +11,7 @@ accepted: true
 category: talks
 date: 2022-10-18 10:40:00-07:00
 end_date: 2022-10-18 11:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Feric-holscher/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feric-holscher/opengraph/
 layout: session-details
 permalink: /talks/documenting-django-code-in-2022/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-11-10-t0-ayudapy-org-from-weekend-project-to-key.md
+++ b/_schedule/talks/2022-10-18-11-10-t0-ayudapy-org-from-weekend-project-to-key.md
@@ -5,7 +5,7 @@ accepted: true
 category: talks
 date: 2022-10-18 11:10:00-07:00
 end_date: 2022-10-18 11:55:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmarcelo-elizeche-lando/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmarcelo-elizeche-lando/opengraph/
 layout: session-details
 permalink: /talks/ayudapy-org-from-weekend-project-to-key/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-11-10-t1-keeping-track-of-architectural-ish-in-a.md
+++ b/_schedule/talks/2022-10-18-11-10-t1-keeping-track-of-architectural-ish-in-a.md
@@ -12,7 +12,7 @@ accepted: true
 category: talks
 date: 2022-10-18 11:10:00-07:00
 end_date: 2022-10-18 11:55:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fjuan-saavedra/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjuan-saavedra/opengraph/
 layout: session-details
 permalink: /talks/keeping-track-of-architectural-ish-in-a/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-00-t0-scheming-with-csrf-when-platforms-manage.md
+++ b/_schedule/talks/2022-10-18-12-00-t0-scheming-with-csrf-when-platforms-manage.md
@@ -7,7 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-18 12:00:00-07:00
 end_date: 2022-10-18 12:25:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkatie-mclaughlin/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkatie-mclaughlin/opengraph/
 layout: session-details
 permalink: /talks/scheming-with-csrf-when-platforms-manage/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-00-t1-django-migrations-pitfalls-and-solutions.md
+++ b/_schedule/talks/2022-10-18-12-00-t1-django-migrations-pitfalls-and-solutions.md
@@ -15,7 +15,7 @@ accepted: true
 category: talks
 date: 2022-10-18 12:00:00-07:00
 end_date: 2022-10-18 12:25:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fbenjamin-zags-zagorsky/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fbenjamin-zags-zagorsky/opengraph/
 layout: session-details
 permalink: /talks/django-migrations-pitfalls-and-solutions/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-18-12-30-t0-lightning-talks.md
@@ -3,7 +3,7 @@ accepted: true
 category: talks
 date: 2022-10-18 12:30:00-07:00
 end_date: 2022-10-18 13:20:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkojo-idrissa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa/opengraph/
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-13-20-t2-type-checking-your-django-code-with-and.md
+++ b/_schedule/talks/2022-10-18-13-20-t2-type-checking-your-django-code-with-and.md
@@ -13,7 +13,7 @@ accepted: true
 category: talks
 date: 2022-10-18 13:20:00-07:00
 end_date: 2022-10-18 14:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkyle-bebak/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkyle-bebak/opengraph/
 layout: session-details
 permalink: /talks/type-checking-your-django-code-with-and/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-00-t0-explaining-explain-a-dive-into-s-explain.md
+++ b/_schedule/talks/2022-10-18-14-00-t0-explaining-explain-a-dive-into-s-explain.md
@@ -4,7 +4,7 @@ accepted: true
 category: talks
 date: 2022-10-18 14:00:00-07:00
 end_date: 2022-10-18 14:45:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Frichard-yen/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Frichard-yen/opengraph/
 layout: session-details
 permalink: /talks/explaining-explain-a-dive-into-s-explain/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-00-t1-building-microservice-architecture-for.md
+++ b/_schedule/talks/2022-10-18-14-00-t1-building-microservice-architecture-for.md
@@ -6,7 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-18 14:00:00-07:00
 end_date: 2022-10-18 14:45:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fsyed-ansab-waqar-gillani/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsyed-ansab-waqar-gillani/opengraph/
 layout: session-details
 permalink: /talks/building-microservice-architecture-for/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-50-t0-lint-all-the-things.md
+++ b/_schedule/talks/2022-10-18-14-50-t0-lint-all-the-things.md
@@ -7,7 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-18 14:50:00-07:00
 end_date: 2022-10-18 15:15:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fluke-lee/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fluke-lee/opengraph/
 layout: session-details
 permalink: /talks/lint-all-the-things/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-50-t1-method-resolution-order-mro-in-python.md
+++ b/_schedule/talks/2022-10-18-14-50-t1-method-resolution-order-mro-in-python.md
@@ -7,7 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-18 14:50:00-07:00
 end_date: 2022-10-18 15:15:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fsanyam-khurana/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsanyam-khurana/opengraph/
 layout: session-details
 permalink: /talks/method-resolution-order-mro-in-python/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-20-t2-lessons-learned-teaching-undergraduate-a.md
+++ b/_schedule/talks/2022-10-18-15-20-t2-lessons-learned-teaching-undergraduate-a.md
@@ -16,7 +16,7 @@ accepted: true
 category: talks
 date: 2022-10-18 15:20:00-07:00
 end_date: 2022-10-18 15:45:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fandrew-mshar/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fandrew-mshar/opengraph/
 layout: session-details
 permalink: /talks/lessons-learned-teaching-undergraduate-a/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-50-t0-just-enough-ops-for-developers.md
+++ b/_schedule/talks/2022-10-18-15-50-t0-just-enough-ops-for-developers.md
@@ -15,7 +15,7 @@ accepted: true
 category: talks
 date: 2022-10-18 15:50:00-07:00
 end_date: 2022-10-18 16:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fpeter-baumgartner/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpeter-baumgartner/opengraph/
 layout: session-details
 permalink: /talks/just-enough-ops-for-developers/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-50-t1-a-management-layer-for-scalable-django.md
+++ b/_schedule/talks/2022-10-18-15-50-t1-a-management-layer-for-scalable-django.md
@@ -10,7 +10,7 @@ accepted: true
 category: talks
 date: 2022-10-18 15:50:00-07:00
 end_date: 2022-10-18 16:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Faddison-hardy/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Faddison-hardy/opengraph/
 layout: session-details
 permalink: /talks/a-management-layer-for-scalable-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-16-40-t0-your-first-deployment-shouldn-t-be-so.md
+++ b/_schedule/talks/2022-10-18-16-40-t0-your-first-deployment-shouldn-t-be-so.md
@@ -8,7 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-18 16:40:00-07:00
 end_date: 2022-10-18 17:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Feric-matthes/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feric-matthes/opengraph/
 layout: session-details
 permalink: /talks/your-first-deployment-shouldn-t-be-so/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-16-40-t1-astrodigenous-an-online-portal-for-sky.md
+++ b/_schedule/talks/2022-10-18-16-40-t1-astrodigenous-an-online-portal-for-sky.md
@@ -21,7 +21,7 @@ accepted: true
 category: talks
 date: 2022-10-18 16:40:00-07:00
 end_date: 2022-10-18 17:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fheidi-white/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fheidi-white/opengraph/
 layout: session-details
 permalink: /talks/astrodigenous-an-online-portal-for-sky/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-17-10-t0-tips-and-tricks-for-optimizing-django.md
+++ b/_schedule/talks/2022-10-18-17-10-t0-tips-and-tricks-for-optimizing-django.md
@@ -12,7 +12,7 @@ accepted: true
 category: talks
 date: 2022-10-18 17:10:00-07:00
 end_date: 2022-10-18 17:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcarmela-beiro/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarmela-beiro/opengraph/
 layout: session-details
 permalink: /talks/tips-and-tricks-for-optimizing-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-17-10-t1-integrating-react-in-the-django-way.md
+++ b/_schedule/talks/2022-10-18-17-10-t1-integrating-react-in-the-django-way.md
@@ -9,7 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-18 17:10:00-07:00
 end_date: 2022-10-18 17:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fjiten-sidhpura/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjiten-sidhpura/opengraph/
 layout: session-details
 permalink: /talks/integrating-react-in-the-django-way/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-17-40-t2-security-best-practices-for-django.md
+++ b/_schedule/talks/2022-10-18-17-40-t2-security-best-practices-for-django.md
@@ -17,9 +17,9 @@ accepted: true
 category: talks
 date: 2022-10-18 17:40:00-07:00
 end_date: 2022-10-18 18:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fgajendra-deshpande/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fgajendra-deshpande/opengraph/
 layout: session-details
-permalink: /talks/security-best-practices-for-django-applications/
+permalink: /talks/security-best-practices-for-django/
 presenter_slugs:
 - gajendra-deshpande
 published: true

--- a/_schedule/talks/2022-10-19-10-40-t2-herding-your-database-queries-diagnosing.md
+++ b/_schedule/talks/2022-10-19-10-40-t2-herding-your-database-queries-diagnosing.md
@@ -8,7 +8,7 @@ accepted: true
 category: talks
 date: 2022-10-19 10:40:00-07:00
 end_date: 2022-10-19 11:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Filya-bass/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Filya-bass/opengraph/
 layout: session-details
 permalink: /talks/herding-your-database-queries-diagnosing/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-11-10-t0-hidden-gems-of-django-admin.md
+++ b/_schedule/talks/2022-10-19-11-10-t0-hidden-gems-of-django-admin.md
@@ -5,7 +5,7 @@ accepted: true
 category: talks
 date: 2022-10-19 11:10:00-07:00
 end_date: 2022-10-19 11:55:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmaxim-danilov/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmaxim-danilov/opengraph/
 layout: session-details
 permalink: /talks/hidden-gems-of-django-admin/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-12-00-t0-async-django-the-practical-guide-you-ve.md
+++ b/_schedule/talks/2022-10-19-12-00-t0-async-django-the-practical-guide-you-ve.md
@@ -6,7 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-19 12:00:00-07:00
 end_date: 2022-10-19 12:25:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fcarlton-gibson/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarlton-gibson/opengraph/
 layout: session-details
 permalink: /talks/async-django-the-practical-guide-you-ve/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-19-12-30-t0-lightning-talks.md
@@ -3,7 +3,7 @@ accepted: true
 category: talks
 date: 2022-10-19 12:30:00-07:00
 end_date: 2022-10-19 13:20:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkojo-idrissa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa/opengraph/
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-13-20-t2-modern-apps-with-django-htmx-tailwind-js.md
+++ b/_schedule/talks/2022-10-19-13-20-t2-modern-apps-with-django-htmx-tailwind-js.md
@@ -9,7 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-19 13:20:00-07:00
 end_date: 2022-10-19 14:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fandrej-baranovskij/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fandrej-baranovskij/opengraph/
 layout: session-details
 permalink: /talks/modern-apps-with-django-htmx-tailwind-js/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-14-00-t0-why-large-django-projects-need-a-data.md
+++ b/_schedule/talks/2022-10-19-14-00-t0-why-large-django-projects-need-a-data.md
@@ -10,7 +10,7 @@ accepted: true
 category: talks
 date: 2022-10-19 14:00:00-07:00
 end_date: 2022-10-19 14:45:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fflavio-juvenal/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fflavio-juvenal/opengraph/
 layout: session-details
 permalink: /talks/why-large-django-projects-need-a-data/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-14-50-t0-a-pythonic-full-text-search.md
+++ b/_schedule/talks/2022-10-19-14-50-t0-a-pythonic-full-text-search.md
@@ -7,7 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-19 14:50:00-07:00
 end_date: 2022-10-19 15:15:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fpaolo-melchiorre/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpaolo-melchiorre/opengraph/
 layout: session-details
 permalink: /talks/a-pythonic-full-text-search/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-15-20-t2-the-software-supply-chain-and-you-how-to.md
+++ b/_schedule/talks/2022-10-19-15-20-t2-the-software-supply-chain-and-you-how-to.md
@@ -7,7 +7,7 @@ accepted: true
 category: talks
 date: 2022-10-19 15:20:00-07:00
 end_date: 2022-10-19 15:45:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Flisa-tagliaferri/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Flisa-tagliaferri/opengraph/
 layout: session-details
 permalink: /talks/the-software-supply-chain-and-you-how-to/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-15-50-t0-home-on-the-range-with-django-getting.md
+++ b/_schedule/talks/2022-10-19-15-50-t0-home-on-the-range-with-django-getting.md
@@ -9,7 +9,7 @@ accepted: true
 category: talks
 date: 2022-10-19 15:50:00-07:00
 end_date: 2022-10-19 16:35:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fjack-linke/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjack-linke/opengraph/
 layout: session-details
 permalink: /talks/home-on-the-range-with-django-getting/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-16-40-t0-how-to-turn-your-website-into-an-app-and.md
+++ b/_schedule/talks/2022-10-19-16-40-t0-how-to-turn-your-website-into-an-app-and.md
@@ -6,7 +6,7 @@ accepted: true
 category: talks
 date: 2022-10-19 16:40:00-07:00
 end_date: 2022-10-19 17:05:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Frussell-keith-magee/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Frussell-keith-magee/opengraph/
 layout: session-details
 permalink: /talks/how-to-turn-your-website-into-an-app-and/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t0-effective-end-to-end-testing-for-django.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t0-effective-end-to-end-testing-for-django.md
@@ -8,7 +8,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 09:00:00-07:00
 end_date: 2022-10-16 12:30:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fed-rivas/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fed-rivas/opengraph/
 layout: session-details
 permalink: /tutorials/effective-end-to-end-testing-for-django/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t1-build-a-production-ready-graphql-api.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t1-build-a-production-ready-graphql-api.md
@@ -6,7 +6,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 09:00:00-07:00
 end_date: 2022-10-16 12:30:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fpatrick-arminio/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpatrick-arminio/opengraph/
 layout: session-details
 permalink: /tutorials/build-a-production-ready-graphql-api/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t2-parlez-vous-django-internationalization.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t2-parlez-vous-django-internationalization.md
@@ -16,7 +16,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 09:00:00-07:00
 end_date: 2022-10-16 12:30:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fmeagen-voss/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmeagen-voss/opengraph/
 layout: session-details
 permalink: /tutorials/parlez-vous-django-internationalization/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t0-it-doesnt-work-a-djangonauts-debugging.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t0-it-doesnt-work-a-djangonauts-debugging.md
@@ -7,7 +7,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 13:30:00-07:00
 end_date: 2022-10-16 17:00:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Ftim-schilling/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Ftim-schilling/opengraph/
 layout: session-details
 permalink: /tutorials/it-doesnt-work-a-djangonauts-debugging/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t1-using-django-for-serving-rest-apis-with.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t1-using-django-for-serving-rest-apis-with.md
@@ -9,7 +9,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 13:30:00-07:00
 end_date: 2022-10-16 17:00:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fkuldeep-pisda/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkuldeep-pisda/opengraph/
 layout: session-details
 permalink: /tutorials/using-django-for-serving-rest-apis-with/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t2-a-detailed-review-for-using-django-and.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t2-a-detailed-review-for-using-django-and.md
@@ -20,7 +20,7 @@ accepted: true
 category: tutorials
 date: 2022-10-16 13:30:00-07:00
 end_date: 2022-10-16 17:00:00-07:00
-image: https://v1.screenshot.11ty.dev/https%3A%2F%2F2022.djangocon.us%2Fpresenters%2Fken-whitesell/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fken-whitesell/opengraph/
 layout: session-details
 permalink: /tutorials/a-detailed-review-for-using-django-and/
 presenter_slugs:

--- a/bin/process.py
+++ b/bin/process.py
@@ -667,7 +667,9 @@ def process(process_presenters: bool = False, slug_max_length: int = 40):
                     presenter_slug = post["presenter_slugs"][0]
                     image_url = f"https://2022.djangocon.us/presenters/{presenter_slug}"
                     image_url = quote_plus(image_url)
-                    post["image"] = f"https://v1.screenshot.11ty.dev/{image_url}/opengraph/"
+                    image_url = quote_plus(image_url)
+                    image_url = f"https://v1.screenshot.11ty.dev/{image_url}/opengraph/"
+                    post["image"] = image_url
 
             if dirty is True:
                 filename.write_text(frontmatter.dumps(post) + "\n")


### PR DESCRIPTION
Fixes #79 

Jekyll SEO is unescaping our escaped encodes image urls and the only workaround I could find was to double-escape them. 