### PR TITLE
🔧 Fix the post image for Ruth's blog post

### DIFF
--- a/_posts/2022-08-02-ruth-ikegah.md
+++ b/_posts/2022-08-02-ruth-ikegah.md
@@ -2,7 +2,7 @@
 author: Drew Winstel
 category: Program
 date: 2022-08-02 11:00:00-07:00
-image: /static/img/social/presenters/ruth-ikegah.jpg
+image: /static/img/presenters/ruth-ikegah.jpg
 layout: post
 title: 'Announcing Our Keynotes: Ruth Ikegah'
 ---


### PR DESCRIPTION
Had the wrong path in the `image` for the post. Whoops.