### PR TITLE
🔧 Fix layouts in Brent's and Ilya's talks

### DIFF
--- a/_schedule/talks/2022-10-17-14-50-t1-herding-your-database-queries-diagnosing.md
+++ b/_schedule/talks/2022-10-17-14-50-t1-herding-your-database-queries-diagnosing.md
@@ -15,7 +15,6 @@ presenter_slugs:
 - ilya-bass
 published: true
 room: Salon F-H
-schedule_layout: full
 sitemap: true
 slug: herding-your-database-queries-diagnosing-improving-and-guarding-performance-of-db-interactions-in-your-django-apps
 summary: ''

--- a/_schedule/talks/2022-10-19-10-40-t2-the-best-of-both-worlds-using-vue-and-in.md
+++ b/_schedule/talks/2022-10-19-10-40-t2-the-best-of-both-worlds-using-vue-and-in.md
@@ -17,6 +17,7 @@ presenter_slugs:
 - levi-mann
 published: true
 room: Online talks
+schedule_layout: full
 sitemap: true
 slug: the-best-of-both-worlds-using-vue-and-django-together-in-a-hybrid-approach
 summary: ''


### PR DESCRIPTION
When I switched the two talks, I forgot to move the schedule layout
over to the online talk.

