### PR TITLE
Adds the DSF and PSF as Community sponsors

### DIFF
--- a/_sponsors/2022-09-09-dsf-community.md
+++ b/_sponsors/2022-09-09-dsf-community.md
@@ -1,0 +1,14 @@
+---
+layout: base
+
+hidden: false
+level: "Community"
+name: "Django Software Foundation"
+logo: "/static/img/sponsors/django-logo-positive.svg"
+logo_orientation: "landscape"
+url_target: "https://www.djangoproject.com/foundation/"
+url_friendly: "djangoproject.com/foundation"
+description: |
+  Development of Django is supported by an independent foundation established as a 501(c)(3) non-profit. Like most open-source foundations, the goal of the Django Software Foundation is to promote, support, and advance its open-source project: in our case, the Django Web framework.
+hiring: false
+---

--- a/_sponsors/2022-09-09-psf-community.md
+++ b/_sponsors/2022-09-09-psf-community.md
@@ -1,0 +1,14 @@
+---
+layout: base
+
+hidden: false
+level: "Community"
+name: "Python Software Foundation"
+logo: "/static/img/sponsors/psf-logo.svg"
+logo_orientation: "landscape"
+url_target: "https://www.python.org/psf/"
+url_friendly: "python.org/psf"
+description: |
+  The Python Software Foundation (PSF) is a 501(c)(3) non-profit corporation that holds the intellectual property rights behind the Python programming language. We manage the open source licensing for Python version 2.1 and later and own and protect the trademarks associated with Python. We also run the North American PyCon conference annually, support other Python conferences around the world, and fund Python related development with our grants program and by funding special projects.
+hiring: false
+---


### PR DESCRIPTION
They are still "Opportunity Grant" sponsors. So they will be listed twice on the sponsors page.

## Screenshot
![Screenshot from 2022-09-09 09-55-05](https://user-images.githubusercontent.com/185043/189401801-09354198-57db-45cc-8fc5-9a16a57f2dc7.png)
