### PR TITLE
:art: OG image fix

### DIFF
--- a/_schedule/sprints/2022-10-20-09-00-getting-started-contributing-to-django.md
+++ b/_schedule/sprints/2022-10-20-09-00-getting-started-contributing-to-django.md
@@ -6,7 +6,7 @@ category: sprints
 date: 2022-10-20 09:00:00-07:00
 end_date: 2022-10-20 12:00:00-07:00
 group: sprints
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarlton-gibson/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarlton-gibson%252Fopengraph%252F
 layout: session-details
 permalink: /sprints/getting-started-contributing-to-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-09-00-orientation-and-welcome.md
+++ b/_schedule/talks/2022-10-17-09-00-orientation-and-welcome.md
@@ -6,7 +6,7 @@ date: 2022-10-17 09:00:00-07:00
 difficulty: All
 end_date: 2022-10-17 09:30:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa%252Fopengraph%252F
 layout: session-details
 permalink: /talks/orientation-and-welcome/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-10-40-t2-working-with-time-series-data-using-and.md
+++ b/_schedule/talks/2022-10-17-10-40-t2-working-with-time-series-data-using-and.md
@@ -12,7 +12,7 @@ category: talks
 date: 2022-10-17 10:40:00-07:00
 end_date: 2022-10-17 11:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjoaquin-scocozza/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjoaquin-scocozza%252Fopengraph%252F
 layout: session-details
 permalink: /talks/working-with-time-series-data-using-and/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-11-10-t0-the-django-admin-is-your-oyster-lets-its.md
+++ b/_schedule/talks/2022-10-17-11-10-t0-the-django-admin-is-your-oyster-lets-its.md
@@ -13,7 +13,7 @@ category: talks
 date: 2022-10-17 11:10:00-07:00
 end_date: 2022-10-17 11:55:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fadrienne-franke/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fadrienne-franke%252Fopengraph%252F
 layout: session-details
 permalink: /talks/the-django-admin-is-your-oyster-lets-its/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-11-10-t1-django-logging-demystified.md
+++ b/_schedule/talks/2022-10-17-11-10-t1-django-logging-demystified.md
@@ -7,7 +7,7 @@ category: talks
 date: 2022-10-17 11:10:00-07:00
 end_date: 2022-10-17 11:55:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Flee-trout/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Flee-trout%252Fopengraph%252F
 layout: session-details
 permalink: /talks/django-logging-demystified/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-00-t0-why-i-didn-t-start-with-django.md
+++ b/_schedule/talks/2022-10-17-12-00-t0-why-i-didn-t-start-with-django.md
@@ -8,7 +8,7 @@ category: talks
 date: 2022-10-17 12:00:00-07:00
 end_date: 2022-10-17 12:25:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmario-munoz/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmario-munoz%252Fopengraph%252F
 layout: session-details
 permalink: /talks/why-i-didn-t-start-with-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-00-t1-documenting-django-code-in-2022.md
+++ b/_schedule/talks/2022-10-17-12-00-t1-documenting-django-code-in-2022.md
@@ -12,7 +12,7 @@ category: talks
 date: 2022-10-17 12:00:00-07:00
 end_date: 2022-10-17 12:25:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feric-holscher/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feric-holscher%252Fopengraph%252F
 layout: session-details
 permalink: /talks/documenting-django-code-in-2022/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-17-12-30-t0-lightning-talks.md
@@ -4,7 +4,7 @@ category: talks
 date: 2022-10-17 12:30:00-07:00
 end_date: 2022-10-17 13:20:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa%252Fopengraph%252F
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-13-20-t2-factory-boy-testing-like-a-pro.md
+++ b/_schedule/talks/2022-10-17-13-20-t2-factory-boy-testing-like-a-pro.md
@@ -8,7 +8,7 @@ date: 2022-10-17 13:20:00-07:00
 difficulty: Intermediate
 end_date: 2022-10-17 14:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcamila-maia/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcamila-maia%252Fopengraph%252F
 layout: session-details
 permalink: /talks/factory-boy-testing-like-a-pro/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-00-t0-you-don-t-need-containers-to-run-django.md
+++ b/_schedule/talks/2022-10-17-14-00-t0-you-don-t-need-containers-to-run-django.md
@@ -10,7 +10,7 @@ category: talks
 date: 2022-10-17 14:00:00-07:00
 end_date: 2022-10-17 14:45:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feduardo-felipe-castegnaro/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feduardo-felipe-castegnaro%252Fopengraph%252F
 layout: session-details
 permalink: /talks/you-don-t-need-containers-to-run-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-00-t1-building-a-dev-focused-learner-system.md
+++ b/_schedule/talks/2022-10-17-14-00-t1-building-a-dev-focused-learner-system.md
@@ -12,7 +12,7 @@ category: talks
 date: 2022-10-17 14:00:00-07:00
 end_date: 2022-10-17 14:45:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsheena-oconnell/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsheena-oconnell%252Fopengraph%252F
 layout: session-details
 permalink: /talks/building-a-dev-focused-learner-system/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-50-t0-predict-lightning-strikes-using-django.md
+++ b/_schedule/talks/2022-10-17-14-50-t0-predict-lightning-strikes-using-django.md
@@ -7,7 +7,7 @@ category: talks
 date: 2022-10-17 14:50:00-07:00
 end_date: 2022-10-17 15:15:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcalvin-hendryx-parker/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcalvin-hendryx-parker%252Fopengraph%252F
 layout: session-details
 permalink: /talks/predict-lightning-strikes-using-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-14-50-t1-herding-your-database-queries-diagnosing.md
+++ b/_schedule/talks/2022-10-17-14-50-t1-herding-your-database-queries-diagnosing.md
@@ -9,7 +9,7 @@ category: talks
 date: 2022-10-17 14:50:00-07:00
 end_date: 2022-10-17 15:15:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Filya-bass/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Filya-bass%252Fopengraph%252F
 layout: session-details
 permalink: /talks/herding-your-database-queries-diagnosing/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-20-t2-a-tour-of-the-sql-server-backend-for.md
+++ b/_schedule/talks/2022-10-17-15-20-t2-a-tour-of-the-sql-server-backend-for.md
@@ -10,7 +10,7 @@ category: talks
 date: 2022-10-17 15:20:00-07:00
 end_date: 2022-10-17 15:45:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fdrew-skwiers-koballa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fdrew-skwiers-koballa%252Fopengraph%252F
 layout: session-details
 permalink: /talks/a-tour-of-the-sql-server-backend-for/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-50-t0-the-django-jigsaw-puzzle-aligning-all.md
+++ b/_schedule/talks/2022-10-17-15-50-t0-the-django-jigsaw-puzzle-aligning-all.md
@@ -5,7 +5,7 @@ category: talks
 date: 2022-10-17 15:50:00-07:00
 end_date: 2022-10-17 16:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fwill-vincent/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fwill-vincent%252Fopengraph%252F
 layout: session-details
 permalink: /talks/the-django-jigsaw-puzzle-aligning-all/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-15-50-t1-war-stories-scaling-django.md
+++ b/_schedule/talks/2022-10-17-15-50-t1-war-stories-scaling-django.md
@@ -6,7 +6,7 @@ category: talks
 date: 2022-10-17 15:50:00-07:00
 end_date: 2022-10-17 16:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fdavid-foster/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fdavid-foster%252Fopengraph%252F
 layout: session-details
 permalink: /talks/war-stories-scaling-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-16-40-t0-nurturing-a-legacy-codebase.md
+++ b/_schedule/talks/2022-10-17-16-40-t0-nurturing-a-legacy-codebase.md
@@ -9,7 +9,7 @@ category: talks
 date: 2022-10-17 16:40:00-07:00
 end_date: 2022-10-17 17:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkaren-tracey/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkaren-tracey%252Fopengraph%252F
 layout: session-details
 permalink: /talks/nurturing-a-legacy-codebase/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-16-40-t1-massively-increase-your-productivity-on.md
+++ b/_schedule/talks/2022-10-17-16-40-t1-massively-increase-your-productivity-on.md
@@ -10,7 +10,7 @@ category: talks
 date: 2022-10-17 16:40:00-07:00
 end_date: 2022-10-17 17:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsimon-willison/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsimon-willison%252Fopengraph%252F
 layout: session-details
 permalink: /talks/massively-increase-your-productivity-on/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-10-t0-fighting-climate-change-with-django.md
+++ b/_schedule/talks/2022-10-17-17-10-t0-fighting-climate-change-with-django.md
@@ -10,7 +10,7 @@ category: talks
 date: 2022-10-17 17:10:00-07:00
 end_date: 2022-10-17 17:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Ferin-mullaney/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Ferin-mullaney%252Fopengraph%252F
 layout: session-details
 permalink: /talks/fighting-climate-change-with-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-10-t1-django-from-queryset-to-serialization.md
+++ b/_schedule/talks/2022-10-17-17-10-t1-django-from-queryset-to-serialization.md
@@ -8,7 +8,7 @@ category: talks
 date: 2022-10-17 17:10:00-07:00
 end_date: 2022-10-17 17:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fiuri-de-silvio/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fiuri-de-silvio%252Fopengraph%252F
 layout: session-details
 permalink: /talks/django-from-queryset-to-serialization/
 presenter_slugs:

--- a/_schedule/talks/2022-10-17-17-40-t2-type-checking-your-django-code-with-and.md
+++ b/_schedule/talks/2022-10-17-17-40-t2-type-checking-your-django-code-with-and.md
@@ -14,7 +14,7 @@ category: talks
 date: 2022-10-17 17:40:00-07:00
 end_date: 2022-10-17 18:30:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkyle-bebak/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkyle-bebak%252Fopengraph%252F
 layout: session-details
 permalink: /talks/type-checking-your-django-code-with-and/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-10-40-t2-i-can-t-believe-it-s-not-real-data-an.md
+++ b/_schedule/talks/2022-10-18-10-40-t2-i-can-t-believe-it-s-not-real-data-an.md
@@ -8,7 +8,7 @@ category: talks
 date: 2022-10-18 10:40:00-07:00
 end_date: 2022-10-18 11:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmason-egger/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmason-egger%252Fopengraph%252F
 layout: session-details
 permalink: /talks/i-can-t-believe-it-s-not-real-data-an/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-11-10-t0-ayudapy-org-from-weekend-project-to-key.md
+++ b/_schedule/talks/2022-10-18-11-10-t0-ayudapy-org-from-weekend-project-to-key.md
@@ -6,7 +6,7 @@ category: talks
 date: 2022-10-18 11:10:00-07:00
 end_date: 2022-10-18 11:55:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmarcelo-elizeche-lando/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmarcelo-elizeche-lando%252Fopengraph%252F
 layout: session-details
 permalink: /talks/ayudapy-org-from-weekend-project-to-key/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-11-10-t1-keeping-track-of-architectural-ish-in-a.md
+++ b/_schedule/talks/2022-10-18-11-10-t1-keeping-track-of-architectural-ish-in-a.md
@@ -13,7 +13,7 @@ category: talks
 date: 2022-10-18 11:10:00-07:00
 end_date: 2022-10-18 11:55:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjuan-saavedra/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjuan-saavedra%252Fopengraph%252F
 layout: session-details
 permalink: /talks/keeping-track-of-architectural-ish-in-a/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-00-t0-scheming-with-csrf-when-platforms-manage.md
+++ b/_schedule/talks/2022-10-18-12-00-t0-scheming-with-csrf-when-platforms-manage.md
@@ -9,7 +9,7 @@ date: 2022-10-18 12:00:00-07:00
 difficulty: All
 end_date: 2022-10-18 12:25:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkatie-mclaughlin/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkatie-mclaughlin%252Fopengraph%252F
 layout: session-details
 permalink: /talks/scheming-with-csrf-when-platforms-manage/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-00-t1-django-migrations-pitfalls-and-solutions.md
+++ b/_schedule/talks/2022-10-18-12-00-t1-django-migrations-pitfalls-and-solutions.md
@@ -17,7 +17,7 @@ date: 2022-10-18 12:00:00-07:00
 difficulty: Intermediate
 end_date: 2022-10-18 12:25:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fbenjamin-zags-zagorsky/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fbenjamin-zags-zagorsky%252Fopengraph%252F
 layout: session-details
 permalink: /talks/django-migrations-pitfalls-and-solutions/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-18-12-30-t0-lightning-talks.md
@@ -4,7 +4,7 @@ category: talks
 date: 2022-10-18 12:30:00-07:00
 end_date: 2022-10-18 13:20:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa%252Fopengraph%252F
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-13-20-t2-how-to-be-a-postgres-dba-in-a-pinch.md
+++ b/_schedule/talks/2022-10-18-13-20-t2-how-to-be-a-postgres-dba-in-a-pinch.md
@@ -10,7 +10,7 @@ date: 2022-10-18 13:20:00-07:00
 end_date: 2022-10-18 14:05:00-07:00
 difficulty: Beginner
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Felizabeth-garrett-christensen/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Felizabeth-garrett-christensen%252Fopengraph%252F
 layout: session-details
 permalink: /talks/how-to-be-a-postgres-dba-in-a-pinch/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-00-t0-explaining-explain-a-dive-into-s-explain.md
+++ b/_schedule/talks/2022-10-18-14-00-t0-explaining-explain-a-dive-into-s-explain.md
@@ -5,7 +5,7 @@ category: talks
 date: 2022-10-18 14:00:00-07:00
 end_date: 2022-10-18 14:45:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Frichard-yen/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Frichard-yen%252Fopengraph%252F
 layout: session-details
 permalink: /talks/explaining-explain-a-dive-into-s-explain/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-00-t1-building-microservice-architecture-for.md
+++ b/_schedule/talks/2022-10-18-14-00-t1-building-microservice-architecture-for.md
@@ -7,7 +7,7 @@ category: talks
 date: 2022-10-18 14:00:00-07:00
 end_date: 2022-10-18 14:45:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsyed-ansab-waqar-gillani/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsyed-ansab-waqar-gillani%252Fopengraph%252F
 layout: session-details
 permalink: /talks/building-microservice-architecture-for/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-50-t0-lint-all-the-things.md
+++ b/_schedule/talks/2022-10-18-14-50-t0-lint-all-the-things.md
@@ -8,7 +8,7 @@ category: talks
 date: 2022-10-18 14:50:00-07:00
 end_date: 2022-10-18 15:15:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fluke-lee/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fluke-lee%252Fopengraph%252F
 layout: session-details
 permalink: /talks/lint-all-the-things/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-14-50-t1-method-resolution-order-mro-in-python.md
+++ b/_schedule/talks/2022-10-18-14-50-t1-method-resolution-order-mro-in-python.md
@@ -8,7 +8,7 @@ category: talks
 date: 2022-10-18 14:50:00-07:00
 end_date: 2022-10-18 15:15:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsanyam-khurana/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fsanyam-khurana%252Fopengraph%252F
 layout: session-details
 permalink: /talks/method-resolution-order-mro-in-python/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-20-t2-lessons-learned-teaching-undergraduate-a.md
+++ b/_schedule/talks/2022-10-18-15-20-t2-lessons-learned-teaching-undergraduate-a.md
@@ -17,7 +17,7 @@ category: talks
 date: 2022-10-18 15:20:00-07:00
 end_date: 2022-10-18 15:45:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fandrew-mshar/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fandrew-mshar%252Fopengraph%252F
 layout: session-details
 permalink: /talks/lessons-learned-teaching-undergraduate-a/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-50-t0-just-enough-ops-for-developers.md
+++ b/_schedule/talks/2022-10-18-15-50-t0-just-enough-ops-for-developers.md
@@ -16,7 +16,7 @@ category: talks
 date: 2022-10-18 15:50:00-07:00
 end_date: 2022-10-18 16:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpeter-baumgartner/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpeter-baumgartner%252Fopengraph%252F
 layout: session-details
 permalink: /talks/just-enough-ops-for-developers/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-15-50-t1-a-management-layer-for-scalable-django.md
+++ b/_schedule/talks/2022-10-18-15-50-t1-a-management-layer-for-scalable-django.md
@@ -11,7 +11,7 @@ category: talks
 date: 2022-10-18 15:50:00-07:00
 end_date: 2022-10-18 16:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Faddison-hardy/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Faddison-hardy%252Fopengraph%252F
 layout: session-details
 permalink: /talks/a-management-layer-for-scalable-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-16-40-t0-your-first-deployment-shouldn-t-be-so.md
+++ b/_schedule/talks/2022-10-18-16-40-t0-your-first-deployment-shouldn-t-be-so.md
@@ -9,7 +9,7 @@ category: talks
 date: 2022-10-18 16:40:00-07:00
 end_date: 2022-10-18 17:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feric-matthes/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Feric-matthes%252Fopengraph%252F
 layout: session-details
 permalink: /talks/your-first-deployment-shouldn-t-be-so/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-16-40-t1-astrodigenous-an-online-portal-for-sky.md
+++ b/_schedule/talks/2022-10-18-16-40-t1-astrodigenous-an-online-portal-for-sky.md
@@ -22,7 +22,7 @@ category: talks
 date: 2022-10-18 16:40:00-07:00
 end_date: 2022-10-18 17:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fheidi-white/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fheidi-white%252Fopengraph%252F
 layout: session-details
 permalink: /talks/astrodigenous-an-online-portal-for-sky/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-17-10-t0-tips-and-tricks-for-optimizing-django.md
+++ b/_schedule/talks/2022-10-18-17-10-t0-tips-and-tricks-for-optimizing-django.md
@@ -13,7 +13,7 @@ category: talks
 date: 2022-10-18 17:10:00-07:00
 end_date: 2022-10-18 17:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarmela-beiro/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarmela-beiro%252Fopengraph%252F
 layout: session-details
 permalink: /talks/tips-and-tricks-for-optimizing-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-17-10-t1-the-software-supply-chain-and-you-how-to.md
+++ b/_schedule/talks/2022-10-18-17-10-t1-the-software-supply-chain-and-you-how-to.md
@@ -9,7 +9,7 @@ date: 2022-10-18 17:10:00-07:00
 difficulty: Beginner
 end_date: 2022-10-18 17:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Flisa-tagliaferri/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Flisa-tagliaferri%252Fopengraph%252F
 layout: session-details
 permalink: /talks/the-software-supply-chain-and-you-how-to/
 presenter_slugs:

--- a/_schedule/talks/2022-10-18-17-40-t2-security-best-practices-for-django.md
+++ b/_schedule/talks/2022-10-18-17-40-t2-security-best-practices-for-django.md
@@ -18,7 +18,7 @@ category: talks
 date: 2022-10-18 17:40:00-07:00
 end_date: 2022-10-18 18:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fgajendra-deshpande/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fgajendra-deshpande%252Fopengraph%252F
 layout: session-details
 permalink: /talks/security-best-practices-for-django/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-10-40-t2-the-best-of-both-worlds-using-vue-and-in.md
+++ b/_schedule/talks/2022-10-19-10-40-t2-the-best-of-both-worlds-using-vue-and-in.md
@@ -10,7 +10,7 @@ date: 2022-10-19 10:40:00-07:00
 difficulty: Intermediate
 end_date: 2022-10-19 11:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fbrent-o-connor/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fbrent-o-connor%252Fopengraph%252F
 layout: session-details
 permalink: /talks/the-best-of-both-worlds-using-vue-and-in/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-11-10-t0-hidden-gems-of-django-admin.md
+++ b/_schedule/talks/2022-10-19-11-10-t0-hidden-gems-of-django-admin.md
@@ -6,7 +6,7 @@ category: talks
 date: 2022-10-19 11:10:00-07:00
 end_date: 2022-10-19 11:55:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmaxim-danilov/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmaxim-danilov%252Fopengraph%252F
 layout: session-details
 permalink: /talks/hidden-gems-of-django-admin/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-12-00-t0-async-django-the-practical-guide-you-ve.md
+++ b/_schedule/talks/2022-10-19-12-00-t0-async-django-the-practical-guide-you-ve.md
@@ -7,7 +7,7 @@ category: talks
 date: 2022-10-19 12:00:00-07:00
 end_date: 2022-10-19 12:25:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarlton-gibson/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fcarlton-gibson%252Fopengraph%252F
 layout: session-details
 permalink: /talks/async-django-the-practical-guide-you-ve/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-12-30-t0-lightning-talks.md
+++ b/_schedule/talks/2022-10-19-12-30-t0-lightning-talks.md
@@ -4,7 +4,7 @@ category: talks
 date: 2022-10-19 12:30:00-07:00
 end_date: 2022-10-19 13:20:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkojo-idrissa%252Fopengraph%252F
 layout: session-details
 permalink: /talks/lightning-talks/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-13-20-t2-modern-apps-with-django-htmx-tailwind-js.md
+++ b/_schedule/talks/2022-10-19-13-20-t2-modern-apps-with-django-htmx-tailwind-js.md
@@ -10,7 +10,7 @@ category: talks
 date: 2022-10-19 13:20:00-07:00
 end_date: 2022-10-19 14:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fandrej-baranovskij/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fandrej-baranovskij%252Fopengraph%252F
 layout: session-details
 permalink: /talks/modern-apps-with-django-htmx-tailwind-js/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-14-00-t0-why-large-django-projects-need-a-data.md
+++ b/_schedule/talks/2022-10-19-14-00-t0-why-large-django-projects-need-a-data.md
@@ -11,7 +11,7 @@ category: talks
 date: 2022-10-19 14:00:00-07:00
 end_date: 2022-10-19 14:45:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fflavio-juvenal/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fflavio-juvenal%252Fopengraph%252F
 layout: session-details
 permalink: /talks/why-large-django-projects-need-a-data/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-14-50-t0-a-pythonic-full-text-search.md
+++ b/_schedule/talks/2022-10-19-14-50-t0-a-pythonic-full-text-search.md
@@ -8,7 +8,7 @@ category: talks
 date: 2022-10-19 14:50:00-07:00
 end_date: 2022-10-19 15:15:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpaolo-melchiorre/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpaolo-melchiorre%252Fopengraph%252F
 layout: session-details
 permalink: /talks/a-pythonic-full-text-search/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-15-20-t2-integrating-react-in-the-django-way.md
+++ b/_schedule/talks/2022-10-19-15-20-t2-integrating-react-in-the-django-way.md
@@ -10,7 +10,7 @@ category: talks
 date: 2022-10-19 15:20:00-07:00
 end_date: 2022-10-19 15:45:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjiten-sidhpura/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjiten-sidhpura%252Fopengraph%252F
 layout: session-details
 permalink: /talks/integrating-react-in-the-django-way/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-15-50-t0-home-on-the-range-with-django-getting.md
+++ b/_schedule/talks/2022-10-19-15-50-t0-home-on-the-range-with-django-getting.md
@@ -10,7 +10,7 @@ category: talks
 date: 2022-10-19 15:50:00-07:00
 end_date: 2022-10-19 16:35:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjack-linke/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fjack-linke%252Fopengraph%252F
 layout: session-details
 permalink: /talks/home-on-the-range-with-django-getting/
 presenter_slugs:

--- a/_schedule/talks/2022-10-19-16-40-t0-how-to-turn-your-website-into-an-app-and.md
+++ b/_schedule/talks/2022-10-19-16-40-t0-how-to-turn-your-website-into-an-app-and.md
@@ -7,7 +7,7 @@ category: talks
 date: 2022-10-19 16:40:00-07:00
 end_date: 2022-10-19 17:05:00-07:00
 group: talks
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Frussell-keith-magee/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Frussell-keith-magee%252Fopengraph%252F
 layout: session-details
 permalink: /talks/how-to-turn-your-website-into-an-app-and/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t0-effective-end-to-end-testing-for-django.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t0-effective-end-to-end-testing-for-django.md
@@ -10,7 +10,7 @@ date: 2022-10-16 09:00:00-07:00
 difficulty: All
 end_date: 2022-10-16 12:30:00-07:00
 group: tutorials
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fed-rivas/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fed-rivas%252Fopengraph%252F
 layout: session-details
 permalink: /tutorials/effective-end-to-end-testing-for-django/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t1-build-a-production-ready-graphql-api.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t1-build-a-production-ready-graphql-api.md
@@ -8,7 +8,7 @@ date: 2022-10-16 09:00:00-07:00
 difficulty: All
 end_date: 2022-10-16 12:30:00-07:00
 group: tutorials
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpatrick-arminio/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fpatrick-arminio%252Fopengraph%252F
 layout: session-details
 permalink: /tutorials/build-a-production-ready-graphql-api/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-09-00-t2-parlez-vous-django-internationalization.md
+++ b/_schedule/tutorials/2022-10-16-09-00-t2-parlez-vous-django-internationalization.md
@@ -18,7 +18,7 @@ date: 2022-10-16 09:00:00-07:00
 difficulty: All
 end_date: 2022-10-16 12:30:00-07:00
 group: tutorials
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmeagen-voss/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmeagen-voss%252Fopengraph%252F
 layout: session-details
 permalink: /tutorials/parlez-vous-django-internationalization/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t0-it-doesnt-work-a-djangonauts-debugging.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t0-it-doesnt-work-a-djangonauts-debugging.md
@@ -9,7 +9,7 @@ date: 2022-10-16 13:30:00-07:00
 difficulty: All
 end_date: 2022-10-16 17:00:00-07:00
 group: tutorials
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Ftim-schilling/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Ftim-schilling%252Fopengraph%252F
 layout: session-details
 permalink: /tutorials/it-doesnt-work-a-djangonauts-debugging/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t1-using-django-for-serving-rest-apis-with.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t1-using-django-for-serving-rest-apis-with.md
@@ -11,7 +11,7 @@ date: 2022-10-16 13:30:00-07:00
 difficulty: All
 end_date: 2022-10-16 17:00:00-07:00
 group: tutorials
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkuldeep-pisda/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fkuldeep-pisda%252Fopengraph%252F
 layout: session-details
 permalink: /tutorials/using-django-for-serving-rest-apis-with/
 presenter_slugs:

--- a/_schedule/tutorials/2022-10-16-13-30-t2-a-detailed-review-for-using-django-and.md
+++ b/_schedule/tutorials/2022-10-16-13-30-t2-a-detailed-review-for-using-django-and.md
@@ -22,7 +22,7 @@ date: 2022-10-16 13:30:00-07:00
 difficulty: All
 end_date: 2022-10-16 17:00:00-07:00
 group: tutorials
-image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fken-whitesell/opengraph/
+image: https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fken-whitesell%252Fopengraph%252F
 layout: session-details
 permalink: /tutorials/a-detailed-review-for-using-django-and/
 presenter_slugs:


### PR DESCRIPTION
OG images weren't being rendered correctly because they were only partially escaped.

```
<meta property="twitter:image" content="https://v1.screenshot.11ty.dev/https%253A%252F%252F2022.djangocon.us%252Fpresenters%252Fmeagen-voss/opengraph/" />
```

