### PR TITLE
Correct COVID testing date in the example

### DIFF
--- a/_pages/covid19.html
+++ b/_pages/covid19.html
@@ -43,7 +43,7 @@ title: COVID-19 In-Person Policy
               </ol>
               <br />
               <br />
-              We are also requiring a negative test before coming to the registration desk on your first day of attendance. If you are taking a PCR test, it must be within 3 days of your first ticketed day (e.g. if you are attending a tutorial, the test must be taken no earlier than Thursday, October 11). If you are taking a rapid test that offers results in under 24 hours, you must take it within 24 hours of your first ticketed day.
+              We are also requiring a negative test before coming to the registration desk on your first day of attendance. If you are taking a PCR test, it must be within 3 days of your first ticketed day (e.g. if you are attending a tutorial, the test must be taken no earlier than Thursday, October 13). If you are taking a rapid test that offers results in under 24 hours, you must take it within 24 hours of your first ticketed day.
               <br />
               <br />
               For vaccine verification, we will be using <a href="https://sharemy.health/">Share My Health</a>, a third-party vendor recognized as a leader in the space, which PyCon US 2022 also used. In order to pass the vaccine verification, you must have be up to date on your vaccine (including eligible boosters). We will be sending the instructions to in-person ticket-holders to verify your vaccine status prior to the conference.


### PR DESCRIPTION
The 11th is a Tuesday. Thursday is the 13th.

Changes proposed in this PR:

- Corrects the example date on the COVID19 page.
