### PR TITLE
📅 Adjust schedule for Tuesday morning

### DIFF
--- a/_schedule/talks/2022-10-18-10-00-t0-opening-remarks.md
+++ b/_schedule/talks/2022-10-18-10-00-t0-opening-remarks.md
@@ -1,8 +1,8 @@
 ---
 accepted: true
 category: talks
-date: 2022-10-18 09:30:00-07:00
-end_date: 2022-10-18 09:45:00-07:00
+date: 2022-10-18 10:00:00-07:00
+end_date: 2022-10-18 10:10:00-07:00
 group: talks
 layout: session-details
 permalink: /talks/opening-remarks-tuesday/

--- a/_schedule/talks/2022-10-18-10-10-t0-keynote-women-of-open-source-community-a.md
+++ b/_schedule/talks/2022-10-18-10-10-t0-keynote-women-of-open-source-community-a.md
@@ -1,7 +1,7 @@
 ---
 accepted: true
 category: talks
-date: 2022-10-18 09:45:00-07:00
+date: 2022-10-18 10:10:00-07:00
 difficulty: All
 end_date: 2022-10-18 10:30:00-07:00
 group: talks


### PR DESCRIPTION
Ruth's keynote came in shorter than expected (18 min), so we'll delay the start of the morning's talks to avoid reshuffling the entire day's talk lineup.

Screenshot:
![image](https://user-images.githubusercontent.com/7773256/194956848-ca5d7325-16c7-4eea-9aac-63393485d6c0.png)
