### PR TITLE
:pencil: Adds stats and no mac

### DIFF
--- a/_pages/homepage-recap.html
+++ b/_pages/homepage-recap.html
@@ -197,8 +197,8 @@ title: 2022 DjangoCon US Recap
           </thead>
           <tbody>
             <tr>
-              <td>Attendees</td>
-              <td>425</td>
+              <td>In-person Attendees</td>
+              <td>502 (272 in-person and 230 online attendees)</td>
             </tr>
             <tr>
               <td>Tutorials</td>
@@ -206,11 +206,7 @@ title: 2022 DjangoCon US Recap
             </tr>
             <tr>
               <td>Talks</td>
-              <td>38</td>
-            </tr>
-            <tr>
-              <td>Favorite food</td>
-              <td>Mac and cheese bar at the opening reception</td>
+              <td>{x} ({y} in-person and {z} online talks)</td>
             </tr>
           </tbody>
         </table>

--- a/_pages/homepage-recap.html
+++ b/_pages/homepage-recap.html
@@ -206,7 +206,7 @@ title: 2022 DjangoCon US Recap
             </tr>
             <tr>
               <td>Talks</td>
-              <td>{x} ({y} in-person and {z} online talks)</td>
+              <td>49 (37 in-person and 12 online talks)</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Starting to add stats... 

We need to pull the CSS from the 2021 recap page to fill in some gaps. 