### PR TITLE
Update AV Checklist for 2022

### DIFF
--- a/_pages/speaking-youtube-checklists.md
+++ b/_pages/speaking-youtube-checklists.md
@@ -31,11 +31,10 @@ Copy title to clipboard
 </div>
 
 <ul>
-  <li><input type="checkbox">YouTube Premiere time set: {{ post.date | date: "%b %d %l:%M %p %Z" }}</li>
   <li><input type="checkbox">Did the link above open the correct video?</li>
   <li><input type="checkbox">Set title from this page</li>
   <li><input type="checkbox">Set description from this page</li>
-  <li><input type="checkbox">Is it on the DjangoCon US 2021 Playlist?</li>
+  <li><input type="checkbox">Is it on the DjangoCon US 2022 Playlist?</li>
   <li><input type="checkbox">Set to "not made for kids"</li>
   <li><input type="checkbox">Set as "contains paid promotion"</li>
   <li><input type="checkbox">Language set appropriately</li>
@@ -47,7 +46,6 @@ Copy title to clipboard
   <li><input type="checkbox">Comments disabled</li>
   <li><input type="checkbox">"show how many viewers like and dislike this video" disabled</li>
   <li><input type="checkbox">English captions uploaded</li>
-  <li><input type="checkbox">Spanish captions uploaded</li>
 </ul>
 
 {% capture youtube-copy-link %}copy-{{ post.slug | slugify }}-youtube{% endcapture %}


### PR DESCRIPTION
From Adam's list from Slack:
- [ ] previous years had the year in the title and when I look it makes sense / is useful
- [ ] I need to make some changes to the checklist too
    - [ ] don’t need premiere times
    - [ ] change 2021 to 2022
    - [ ] remove Spanish caption item
- [ ] and then if it parallelizes have some way of tracking which have been done